### PR TITLE
[changed] Update to React 0.12. Fix warnings.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -1,6 +1,5 @@
-/** @jsx React.DOM */
 var React = require('react');
-var ModalPortal = require('./ModalPortal');
+var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
 var injectCSS = require('../helpers/injectCSS');
 
@@ -53,7 +52,7 @@ var Modal = module.exports = React.createClass({
     if (this.portal)
       this.portal.setProps(props);
     else
-      this.portal = React.renderComponent(ModalPortal(props), this.node);
+      this.portal = React.render(ModalPortal(props), this.node);
   },
 
   render: function () {

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.3",
     "mocha": "1.20.1",
-    "react": ">=0.11.0",
+    "react": ">=0.12.0",
     "reactify": "^0.14.0",
     "rf-release": "0.3.1",
     "uglify-js": "2.4.15",
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {
-    "react": ">=0.11.0"
+    "react": ">=0.12.0"
   },
   "dependencies": {},
   "tags": [

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -1,6 +1,6 @@
 require('./helper');
-var Modal = require('../lib/components/Modal');
 var React = require('react/addons');
+var Modal = require('../lib/components/Modal');
 var Simulate = React.addons.TestUtils.Simulate;
 var ariaAppHider = require('../lib/helpers/ariaAppHider');
 var button = React.DOM.button;
@@ -26,7 +26,7 @@ describe('Modal', function () {
   it('throws without an appElement', function() {
     var node = document.createElement('div');
     throws(function() {
-      React.renderComponent(Modal({isOpen: true}), node);
+      React.render(React.createElement(Modal, {isOpen: true}), node);
     });
     React.unmountComponentAtNode(node);
   });
@@ -35,7 +35,7 @@ describe('Modal', function () {
     var app = document.createElement('div');
     var node = document.createElement('div');
     Modal.setAppElement(app);
-    React.renderComponent(Modal({isOpen: true}), node);
+    React.render(React.createElement(Modal, {isOpen: true}), node);
     equal(app.getAttribute('aria-hidden'), 'true');
     ariaAppHider.resetForTesting();
     React.unmountComponentAtNode(node);
@@ -44,7 +44,7 @@ describe('Modal', function () {
   it('accepts appElement as a prop', function() {
     var el = document.createElement('div');
     var node = document.createElement('div');
-    React.renderComponent(Modal({
+    React.render(React.createElement(Modal, {
       isOpen: true,
       appElement: el
     }), node);
@@ -56,10 +56,10 @@ describe('Modal', function () {
     var node = document.createElement('div');
     var App = React.createClass({
       render: function() {
-        return React.DOM.div({}, Modal({isOpen: true, ariaHideApp: false}, 'hello'));
+        return React.DOM.div({}, React.createElement(Modal, {isOpen: true, ariaHideApp: false}, 'hello'));
       }
     });
-    React.renderComponent(App(), node);
+    React.render(React.createElement(App), node);
     var modalParent = document.body.querySelector('.ReactModalPortal').parentNode;
     equal(modalParent, document.body);
     React.unmountComponentAtNode(node);
@@ -75,7 +75,7 @@ describe('Modal', function () {
   it('has default props', function() {
     var node = document.createElement('div');
     Modal.setAppElement(document.createElement('div'));
-    var component = React.renderComponent(Modal(), node);
+    var component = React.render(React.createElement(Modal), node);
     var props = component.props;
     equal(props.isOpen, false);
     equal(props.ariaHideApp, true);
@@ -116,13 +116,13 @@ describe('Modal', function () {
   //it('adds --before-close for animations', function() {
     //var node = document.createElement('div');
 
-    //var component = React.renderComponent(Modal({
+    //var component = React.render(React.createElement(Modal, {
       //isOpen: true,
       //ariaHideApp: false,
       //closeTimeoutMS: 50,
     //}), node);
 
-    //component = React.renderComponent(Modal({
+    //component = React.render(React.createElement(Modal, {
       //isOpen: false,
       //ariaHideApp: false,
       //closeTimeoutMS: 50,

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -1,6 +1,6 @@
 assert = require('assert');
 React = require('react/addons');
-var Modal = require('../lib/components/Modal');
+var Modal = React.createFactory(require('../lib/components/Modal'));
 
 ReactTestUtils = React.addons.TestUtils;
 ok = assert.ok;
@@ -14,7 +14,7 @@ renderModal = function(props, children, callback) {
   props.ariaHideApp = false;
   _currentDiv = document.createElement('div');
   document.body.appendChild(_currentDiv);
-  return React.renderComponent(Modal(props, children), _currentDiv, callback);
+  return React.render(Modal(props, children), _currentDiv, callback);
 };
 
 unmountModal = function() {


### PR DESCRIPTION
This PR makes react-modal require react 0.12 or latest. Also fixes the warnings and deprecation notices caused by the new API.

The migration plan is the same published by the React team when migrating from older versions to React 0.12.
