### PR TITLE
[fixed] erroneous alias in webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,12 +39,6 @@ module.exports = {
     ]
   },
 
-  resolve: {
-    alias: {
-      'react-router': '../../modules/index'
-    }
-  },
-
   plugins: [
     new webpack.optimize.CommonsChunkPlugin('shared.js')
   ]


### PR DESCRIPTION
alias for react-router is not needed
