### PR TITLE
[fixed] Remove ReactModal__Body--open class when unmounting Modal

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -59,6 +59,7 @@ var Modal = module.exports = React.createClass({
   componentWillUnmount: function() {
     ReactDOM.unmountComponentAtNode(this.node);
     AppElement.removeChild(this.node);
+    elementClass(document.body).remove('ReactModal__Body--open');
   },
 
   renderPortal: function(props) {

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -175,6 +175,13 @@ describe('Modal', function () {
     unmountModal();
   });
 
+  it('removes class from body when unmounted without closing', function() {
+    var modal = renderModal({isOpen: true});
+    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, true);
+    unmountModal();
+    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, false);
+  });
+
   it('adds --after-open for animations', function() {
     var modal = renderModal({isOpen: true});
     var overlay = document.querySelector('.ReactModal__Overlay');


### PR DESCRIPTION
This fixes a bug where if a modal was unmounted without closing first, the `ReactModal__Body--open` stays on the `body` element.

This causes issues when, for example, you have a react-router link in a modal that takes you directly to another route handler component. The expected behavior for this is the modal closes and all page state related to the modal having been open is reset.
