### PR TITLE
Ability to anchor modals relatively to its context rather than just the body.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -21,6 +21,7 @@ var Modal = module.exports = React.createClass({
   },
 
   propTypes: {
+    relative: React.PropTypes.bool,
     isOpen: React.PropTypes.bool.isRequired,
     style: React.PropTypes.shape({
       content: React.PropTypes.object,
@@ -34,6 +35,7 @@ var Modal = module.exports = React.createClass({
 
   getDefaultProps: function () {
     return {
+      relative: false,
       isOpen: false,
       ariaHideApp: true,
       closeTimeoutMS: 0
@@ -41,9 +43,10 @@ var Modal = module.exports = React.createClass({
   },
 
   componentDidMount: function() {
+    this.anchor = (this.props.relative) ? ReactDOM.findDOMNode(this).parentNode : document.body;
     this.node = document.createElement('div');
     this.node.className = 'ReactModalPortal';
-    document.body.appendChild(this.node);
+    this.anchor.appendChild(this.node);
     this.renderPortal(this.props);
   },
 
@@ -53,14 +56,14 @@ var Modal = module.exports = React.createClass({
 
   componentWillUnmount: function() {
     ReactDOM.unmountComponentAtNode(this.node);
-    document.body.removeChild(this.node);
+    this.anchor.removeChild(this.node);
   },
 
   renderPortal: function(props) {
     if (props.isOpen) {
-      elementClass(document.body).add('ReactModal__Body--open');
+      elementClass(this.anchor).add('ReactModal__Body--open');
     } else {
-      elementClass(document.body).remove('ReactModal__Body--open');
+      elementClass(this.anchor).remove('ReactModal__Body--open');
     }
 
     if (props.ariaHideApp) {

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -19,28 +19,30 @@ var CLASS_NAMES = {
   }
 };
 
-var defaultStyles = {
-  overlay: {
-    position        : 'fixed',
-    top             : 0,
-    left            : 0,
-    right           : 0,
-    bottom          : 0,
-    backgroundColor : 'rgba(255, 255, 255, 0.75)'
-  },
-  content: {
-    position                : 'absolute',
-    top                     : '40px',
-    left                    : '40px',
-    right                   : '40px',
-    bottom                  : '40px',
-    border                  : '1px solid #ccc',
-    background              : '#fff',
-    overflow                : 'auto',
-    WebkitOverflowScrolling : 'touch',
-    borderRadius            : '4px',
-    outline                 : 'none',
-    padding                 : '20px'
+function defaultStyles(relative) {
+  return {
+    overlay: {
+      position        : relative ? 'absolute' : 'fixed',
+      top             : 0,
+      left            : 0,
+      right           : 0,
+      bottom          : 0,
+      backgroundColor : 'rgba(255, 255, 255, 0.75)'
+    },
+    content: {
+      position                : 'absolute',
+      top                     : '40px',
+      left                    : '40px',
+      right                   : '40px',
+      bottom                  : '40px',
+      border                  : '1px solid #ccc',
+      background              : '#fff',
+      overflow                : 'auto',
+      WebkitOverflowScrolling : 'touch',
+      borderRadius            : '4px',
+      outline                 : 'none',
+      padding                 : '20px'
+    }
   }
 };
 
@@ -179,12 +181,12 @@ var ModalPortal = module.exports = React.createClass({
       div({
         ref: "overlay",
         className: this.buildClassName('overlay', this.props.overlayClassName),
-        style: Assign({}, defaultStyles.overlay, this.props.style.overlay || {}),
+        style: Assign({}, defaultStyles(this.props.relative).overlay, this.props.style.overlay || {}),
         onClick: this.handleOverlayClick
       },
         div({
           ref: "content",
-          style: Assign({}, defaultStyles.content, this.props.style.content || {}),
+          style: Assign({}, defaultStyles(this.props.relative).content, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
           tabIndex: "-1",
           onClick: stopPropagation,

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -46,6 +46,31 @@ describe('Modal', function () {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  it('relative modals render into context, not in body', function() {
+    var node = document.createElement('div');
+    var App = React.createClass({
+      render: function() {
+        return React.DOM.div({ id: 'context' }, React.createElement(Modal, {isOpen: true, relative: true}, 'hello'));
+      }
+    });
+    ReactDOM.render(React.createElement(App), node);
+    var modalParent = node.querySelector('.ReactModalPortal').parentNode;
+    equal(modalParent.id, 'context')
+    ReactDOM.unmountComponentAtNode(node)
+  });
+
+  it('modal overlays have default fixed position', function() {
+    var modal = renderModal({isOpen: true});
+    equal(modal.portal.refs.overlay.style.position, 'fixed');
+    unmountModal();
+  });
+
+  it('relative modal overlays have default absolute position', function() {
+    var modal = renderModal({isOpen: true, relative: true});
+    equal(modal.portal.refs.overlay.style.position, 'absolute');
+    unmountModal();
+  });
+
   it('renders into the body, not in context', function() {
     var node = document.createElement('div');
     var App = React.createClass({


### PR DESCRIPTION
This can be done just by setting the prop `relative = true`.

Here are the possible use cases:
- When you want a modal to appear on a particular part of the page.
- Multiple modals to appear on different parts of the page.

I don't think the current release solves these use cases already. Please correct me if I'm wrong.