### PR TITLE
Make README example consistent with examples/basic/app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Styles are passed as an object with 2 keys, 'overlay' and 'content' like so
     borderRadius               : '4px',
     outline                    : 'none',
     padding                    : '20px'
-
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var App = React.createClass({
         <Modal
           isOpen={this.state.modalIsOpen}
           onRequestClose={this.closeModal}
-          style={customStyles} >
+          style={customStyles}>
 
           <h2>Hello</h2>
           <button onClick={this.closeModal}>close</button>

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ var App = React.createClass({
           isOpen={this.state.modalIsOpen}
           onRequestClose={this.closeModal}
           style={customStyles}>
-
           <h2>Hello</h2>
           <button onClick={this.closeModal}>close</button>
           <div>I am a modal</div>


### PR DESCRIPTION
Just some fixes on small inconsistencies (new lines, space) that I noticed when comparing examples/basic/app.js with the README example.
