### PR TITLE
[Fixed] Prevent default behavior of ESC key

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -142,7 +142,10 @@ var ModalPortal = module.exports = React.createClass({
 
   handleKeyDown: function(event) {
     if (event.keyCode == 9 /*tab*/) scopeTab(this.refs.content, event);
-    if (event.keyCode == 27 /*esc*/) this.requestClose();
+    if (event.keyCode == 27 /*esc*/) {
+      event.preventDefault();
+      this.requestClose();
+    }
   },
 
   handleOverlayClick: function() {


### PR DESCRIPTION
Following problem is happened in my app.

- Close modal with ESC key
- HttpRequest which runs after closing modal is canceled
  - Because of ESC key
