### PR TITLE
[fixed] Clear the delayed close timer when modal opens again

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -102,11 +102,16 @@ var ModalPortal = module.exports = React.createClass({
   },
 
   open: function() {
-    focusManager.setupScopedFocus(this.node);
-    focusManager.markForFocusLater();
-    this.setState({isOpen: true}, function() {
-      this.setState({afterOpen: true});
-    }.bind(this));
+    if (this.state.afterOpen && this.state.beforeClose) {
+      clearTimeout(this.closeTimer);
+      this.setState({ beforeClose: false });
+    } else {
+      focusManager.setupScopedFocus(this.node);
+      focusManager.markForFocusLater();
+      this.setState({isOpen: true}, function() {
+        this.setState({afterOpen: true});
+      }.bind(this));
+    }
   },
 
   close: function() {


### PR DESCRIPTION
Currently there is an inconsistency when there is a delayed close and right after the start of this close the modal opens again.
Graphic:
```
| closeWithTimeout
|   setState - beforeClose: true
| open
|   setState - isOpen: true
|   setState - afterOpen: true
| closeWithoutTimeout
|   setState - beforeClose: false
|   setState - afterOpen: false
v
```
Now we have this state:
```javascript
{
  beforeClose: false,
  isOpen: true,
  afterOpen: false,
}
```

Which gives an invisible modal.

This PR should fix it by just skipping the open logic (since the modal is already open) and clearing the timeout and returning beforeClose to false.