### PR TITLE
add missing webpack devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "karma-mocha": "0.2.0",
     "karma-safari-launcher": "^0.1.1",
     "mocha": "2.3.3",
+    "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react": "^0.14.0",
     "reactify": "^1.1.1",
     "rf-release": "0.4.0",
     "uglify-js": "2.4.24",
+    "webpack": "^1.12.14",
     "webpack-dev-server": "1.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
Without `webpack` dependency the `dev-examples` script doesn't work (unless you have `webpack` installed globally) and the example files aren't built.