### PR TITLE
Fix no tabbable focus

### DIFF
--- a/lib/helpers/scopeTab.js
+++ b/lib/helpers/scopeTab.js
@@ -2,7 +2,10 @@ var findTabbable = require('../helpers/tabbable');
 
 module.exports = function(node, event) {
   var tabbable = findTabbable(node);
-  if (!tabbable.length) return;
+  if (!tabbable.length) {
+      event.preventDefault();
+      return;
+  }
   var finalTabbable = tabbable[event.shiftKey ? 0 : tabbable.length - 1];
   var leavingFinalTabbable = (
     finalTabbable === document.activeElement ||

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -100,6 +100,19 @@ describe('Modal', function () {
     unmountModal();
   });
 
+  it('keeps focus inside the modal when child has no tabbable elements', function() {
+    var tabPrevented = false;
+    var modal = renderModal({isOpen: true}, 'hello');
+    strictEqual(document.activeElement, modal.portal.refs.content);
+    Simulate.keyDown(modal.portal.refs.content, {
+        key: "Tab",
+        keyCode: 9,
+        which: 9,
+        preventDefault: function() { tabPrevented = true; }
+    });
+    equal(tabPrevented, true);
+  });
+
   it('supports custom className', function() {
     var modal = renderModal({isOpen: true, className: 'myClass'});
     equal(modal.portal.refs.content.className.contains('myClass'), true);


### PR DESCRIPTION
A follow up to https://github.com/reactjs/react-modal/pull/120.
This is a better way to handle the case when no tabbable elements are found within the modal's content.
The focus should be kept inside the modal the same way it's kept when there are some elements.