### PR TITLE
make all tests pass within es5 environment

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -102,13 +102,13 @@ describe('Modal', function () {
 
   it('supports custom className', function() {
     var modal = renderModal({isOpen: true, className: 'myClass'});
-    equal(modal.portal.refs.content.className.contains('myClass'), true);
+    equal(modal.portal.refs.content.className.indexOf('myClass') !== -1, true);
     unmountModal();
   });
 
   it('supports overlayClassName', function () {
     var modal = renderModal({isOpen: true, overlayClassName: 'myOverlayClass'});
-    equal(modal.portal.refs.overlay.className.contains('myOverlayClass'), true);
+    equal(modal.portal.refs.overlay.className.indexOf('myOverlayClass') !== -1, true);
     unmountModal();
   });
 


### PR DESCRIPTION
All code for this library is written in `es5`, except for these two tests. So they fail when run in es5 environment. This PR fixes that.