### PR TITLE
Add extra information for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+### Summary:
+
+### Steps to reproduce:
+
+ 1.
+ 2.
+ 3.
+
+### Expected behavior:
+
+### Additional notes:
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Fixes #[issue number].
+
+Changes proposed:
+-
+-
+-
+
+Upgrade Path (for changed or removed APIs):
+
+
+Acceptance Checklist:
+[ ] All commits have been squashed to one.
+[ ] The commit message follows the guidlines in `CONTRIBUTING.md`.
+[ ] Documentation (README.md) and examples have been updated as needed.
+[ ] If this is a code change, a spec testing the functionality has been added.
+[ ] If the commit message has [changed] or [removed], there is an upgrade path above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ always be in sync.
 ### Development
 
 - `npm start` runs the dev server to run/develop examples
-- `npm test` will run the test.
+- `npm test` will run the tests.
 - `scripts/test` same as `npm test` but keeps karma running and watches
   for changes
 


### PR DESCRIPTION
This commit adds templates for pull requests and issues.
The goal is to help those contributing to the project to
get their issues handled quicker and their pull requests
reviewed and merged quicker and more efficiently.

Please review these changes and let me know if this is something that the community here
would be willing to do.