### PR TITLE
Move to using webpack for building the library

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "browserify": "11.1.0",
-    "browserify-shim": "3.8.10",
-    "envify": "3.4.0",
+    "babel-core": "^6.7.4",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "expect": "1.10.0",
-    "jsx-loader": "0.13.2",
     "karma": "0.13.10",
     "karma-browserify": "^4.2.1",
     "karma-chrome-launcher": "0.2.0",
@@ -37,7 +37,6 @@
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
-    "reactify": "^1.1.1",
     "rf-release": "0.4.0",
     "sinon": "^1.17.3",
     "uglify-js": "2.4.24",
@@ -62,9 +61,5 @@
     "react-component",
     "modal",
     "dialog"
-  ],
-  "browserify-shim": {
-    "react": "global:React",
-    "react-dom": "global:ReactDOM"
-  }
+  ]
 }

--- a/scripts/build
+++ b/scripts/build
@@ -1,11 +1,2 @@
 #!/bin/sh
-mkdir -p dist
-NODE_ENV=production node_modules/.bin/browserify lib/index.js \
-  -t reactify \
-  -t browserify-shim \
-  -t envify \
-  --detect-globals false \
-  -s ReactModal > dist/react-modal.js
-node_modules/.bin/uglifyjs dist/react-modal.js \
-  --compress warnings=false > dist/react-modal.min.js
-
+webpack --config webpack.dist.config.js

--- a/scripts/build
+++ b/scripts/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-webpack --config webpack.dist.config.js
+webpack --config webpack.dist.config.js -p

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, loader: 'jsx-loader?harmony' }
+      { test: /\.js$/, loader: 'babel' }
     ]
   },
 

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -1,0 +1,40 @@
+var webpack = require('webpack');
+var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
+var env = process.env.WEBPACK_ENV;
+
+module.exports = {
+
+  entry: {
+    'react-modal': './lib/index.js',
+    'react-modal.min': './lib/index.js'
+  },
+
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[id].chunk.js',
+    path: 'dist',
+    publicPath: '/',
+    libraryTarget: 'umd',
+    library: 'ReactModal'
+  },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    }),
+    new UglifyJsPlugin({
+      include: /\.min\.js$/,
+      minimize: true,
+      compress: {
+        warnings: false
+      }
+    })
+  ],
+
+  module: {
+    loaders: [
+      { test: /\.js?$/, exclude: /node_modules/, loader: 'babel'},
+    ]
+  }
+
+};

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -9,6 +9,11 @@ module.exports = {
     'react-modal.min': './lib/index.js'
   },
 
+  externals: [
+    'react',
+    'react-dom'
+  ],
+
   output: {
     filename: '[name].js',
     chunkFilename: '[id].chunk.js',


### PR DESCRIPTION
This allows us to remove the dependency on browserify
completely.

The problem is that the size of the compiled library is 719 kB unminified and 190 kB minified.  The current implementation via browserify produces 49 kB unminified and 21 kB minified.  That's quite the difference.

Any ideas on how to get that down?