### PR TITLE
[fixed] scopeTab no longer attempts to focus on undefined target

### DIFF
--- a/lib/helpers/scopeTab.js
+++ b/lib/helpers/scopeTab.js
@@ -15,5 +15,7 @@ module.exports = function(node, event) {
   if (!leavingFinalTabbable) return;
   event.preventDefault();
   var target = tabbable[event.shiftKey ? tabbable.length - 1 : 0];
-  target.focus();
+  if (target) {
+      target.focus();
+  }
 };


### PR DESCRIPTION
When creating a modal with nothing tabbable inside it, I was getting `Cannot read property 'focus' of undefined` errors if I hit the Tab key (which was being listened to by another component). This PR will prevent that error from occurring.