### PR TITLE
[changed] Fixes #151 adds support for React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "karma-mocha": "0.2.0",
     "karma-safari-launcher": "^0.1.1",
     "mocha": "2.3.3",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "reactify": "^1.1.1",
     "rf-release": "0.4.0",
     "sinon": "^1.17.3",
@@ -50,7 +50,7 @@
     "lodash.assign": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "tags": [
     "react",


### PR DESCRIPTION
Just some `package.json` changes to add support for React 15. Fixes issue #151 

Testing done:

- `npm run start` example works without any errors or warnings in Chrome 49 on Windows and Firefox 44 on Windows
- `npm run test` reports no errors

From what I see, it's safe to merge.