### PR TITLE
Use -p flag in webpack for minification and exclude externals react a…

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-webpack --config webpack.dist.config.js
+webpack --config webpack.dist.config.js -p

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -9,6 +9,11 @@ module.exports = {
     'react-modal.min': './lib/index.js'
   },
 
+  externals: [
+    'react',
+    'react-dom'
+  ],
+
   output: {
     filename: '[name].js',
     chunkFilename: '[id].chunk.js',


### PR DESCRIPTION
Fixes #144 .

Changes proposed:
- Use `webpack -p` for minification instead of UglifyJS Plugin
- Designate `react` and `react-dom` as externals in webpack config to exclude them from build

Reduces minified build size to 14.4kB.