### PR TITLE
[fixed] moved sanitizeProps() out of the renderPortal call.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -55,6 +55,7 @@ var Modal = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
+    sanitizeProps(newProps);
     this.renderPortal(newProps);
   },
 
@@ -75,7 +76,6 @@ var Modal = React.createClass({
       ariaAppHider.toggle(props.isOpen, props.appElement);
     }
 
-    sanitizeProps(props);
     this.portal = renderSubtreeIntoContainer(this, ModalPortal(Assign({}, props, {defaultStyles: Modal.defaultStyles})), this.node);
   },
 


### PR DESCRIPTION
Fixes #160.

`
Error:
Uncaught TypeError: Cannot delete property 'ref' of #<Object>.
`