### PR TITLE
[fixed] Make the non-minified dist build present again

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-webpack --config webpack.dist.config.js -p
+webpack --config webpack.dist.config.js


### PR DESCRIPTION
Fixes #163 .

Changes proposed:
-  Adds back a non-minified build


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidlines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.

This commit removes the `-p` flag from the call to webpack
so that the webpack config works as intended, creating two
files in the dist directory, one minified and one unminified.

After 3f323381b1e8c43fdbf172813b9e8a4ace9abe79 was merged the
build ended up only producing the production minified versions
for both files.  This commit restores the initial behavior
of a non-minified and a minified file.