### PR TITLE
[added] Append document.body if non-existent (#170)

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -8,7 +8,9 @@ var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeInto
 var Assign = require('lodash.assign');
 
 var SafeHTMLElement = ExecutionEnvironment.canUseDOM ? window.HTMLElement : {};
-var AppElement = ExecutionEnvironment.canUseDOM ? document.body : {appendChild: function() {}};
+
+var body = document.body ? document.body : dom.documentElement.appendChild("body");
+var AppElement = ExecutionEnvironment.canUseDOM ? body : {appendChild: function() {}};
 
 var Modal = React.createClass({
 

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -13,7 +13,6 @@ describe('Modal', function () {
   it('scopes tab navigation to the modal');
   it('focuses the last focused element when tabbing in from browser chrome');
 
-
   it('can be open initially', function() {
     var component = renderModal({isOpen: true}, 'hello');
     equal(component.portal.refs.content.innerHTML.trim(), 'hello');
@@ -48,6 +47,11 @@ describe('Modal', function () {
     }), node);
     equal(el.getAttribute('aria-hidden'), 'true');
     ReactDOM.unmountComponentAtNode(node);
+  });
+
+  it('checks for document.body and appends one if none exists', function() {
+    var body = document.body ? document.body : dom.documentElement.appendChild("body");
+    equal(body, document.body);
   });
 
   it('renders into the body, not in context', function() {


### PR DESCRIPTION
Fixes #[170].

Changes proposed:
-Check if `document.body` exists, if not then append one
-Add `var body` which equals to `document.body` or appended `body`
-Use var body rather than document.body in `AppElement`

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
[x] All commits have been squashed to one.
[x] The commit message follows the guidlines in `CONTRIBUTING.md`.
[ ] Documentation (README.md) and examples have been updated as needed.
[x] If this is a code change, a spec testing the functionality has been added.
[ ] If the commit message has [changed] or [removed], there is an upgrade path above.

