### PR TITLE
[fixed] Make the modal portal render into body again

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -50,7 +50,7 @@ var Modal = React.createClass({
   componentDidMount: function() {
     this.node = document.createElement('div');
     this.node.className = 'ReactModalPortal';
-    AppElement.appendChild(this.node);
+    document.body.appendChild(this.node);
     this.renderPortal(this.props);
   },
 
@@ -60,7 +60,7 @@ var Modal = React.createClass({
 
   componentWillUnmount: function() {
     ReactDOM.unmountComponentAtNode(this.node);
-    AppElement.removeChild(this.node);
+    document.body.removeChild(this.node);
     elementClass(document.body).remove('ReactModal__Body--open');
   },
 

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -26,19 +26,6 @@ describe('Modal', function () {
     unmountModal();
   });
 
-  it('uses the global appElement', function() {
-    var app = document.createElement('div');
-    var node = document.createElement('div');
-    Modal.setAppElement(app);
-    ReactDOM.render(React.createElement(Modal, {isOpen: true}), node);
-    var modalParent = app.querySelector('.ReactModalPortal').parentNode;
-    assert.notEqual(modalParent, document.body);
-    assert.equal(modalParent, app);
-    equal(app.getAttribute('aria-hidden'), 'true');
-    ariaAppHider.resetForTesting();
-    ReactDOM.unmountComponentAtNode(node);
-  });
-
   it('accepts appElement as a prop', function() {
     var el = document.createElement('div');
     var node = document.createElement('div');
@@ -54,10 +41,10 @@ describe('Modal', function () {
     var node = document.createElement('div');
     var App = React.createClass({
       render: function() {
-        return React.DOM.div({}, React.createElement(Modal, {isOpen: true, ariaHideApp: false}, 'hello'));
+        return React.DOM.div({}, React.createElement(Modal, {isOpen: true}, 'hello'));
       }
     });
-    Modal.setAppElement(document.body);
+    Modal.setAppElement(node);
     ReactDOM.render(React.createElement(App), node);
     var modalParent = document.body.querySelector('.ReactModalPortal').parentNode;
     equal(modalParent, document.body);


### PR DESCRIPTION
In c13fed9f3a1270a4ecfb6faf24355f2791948c00 behavior was changed
so that the modal portal ended up rendering into the app element.

In the default case where the appElement receives aria-hidden
when the modal is open, this meant that the modal itself was
also contained inside the aria-hidden element.  This limits the
ability for screenreaders to read the modal contents.

Server-side rendering should not be affected by this change
because componentDidMount is only fired on the client-side thus
having a reference to document.body there should be acceptable.

Changes proposed:
- Make the portal append to body rather than the app element

Upgrade Path (for changed or removed APIs):
- Make sure that you are setting an app element (rather than using the default document.body) so that modal contents are not being aria-hidden

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

