### PR TITLE
[fixed] clear the delayed close timer when modal opens again.

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -72,15 +72,20 @@ var ModalPortal = module.exports = React.createClass({
   },
 
   open: function() {
-    focusManager.setupScopedFocus(this.node);
-    focusManager.markForFocusLater();
-    this.setState({isOpen: true}, function() {
-      this.setState({afterOpen: true});
+    if (this.state.afterOpen && this.state.beforeClose) {
+      clearTimeout(this.closeTimer);
+      this.setState({ beforeClose: false });
+    } else {
+      focusManager.setupScopedFocus(this.node);
+      focusManager.markForFocusLater();
+      this.setState({isOpen: true}, function() {
+        this.setState({afterOpen: true});
 
-      if (this.props.isOpen && this.props.onAfterOpen) {
-        this.props.onAfterOpen();
-      }
-    }.bind(this));
+        if (this.props.isOpen && this.props.onAfterOpen) {
+          this.props.onAfterOpen();
+        }
+      }.bind(this));
+    }
   },
 
   close: function() {

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -109,8 +109,9 @@ var ModalPortal = module.exports = React.createClass({
 
   closeWithoutTimeout: function() {
     this.setState({
+      beforeClose: false,
+      isOpen: false,
       afterOpen: false,
-      beforeClose: false
     }, this.afterClose);
   },
 

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -200,6 +200,20 @@ describe('Modal', function () {
     unmountModal();
   });
 
+  it('check the state of the modal after close with time out and reopen it', function() {
+    var afterOpenCallback = sinon.spy();
+    var modal = renderModal({
+      isOpen: true,
+      closeTimeoutMS: 2000,
+      onRequestClose: function() {}
+    });
+    modal.portal.closeWithTimeout();
+    modal.portal.open();
+    modal.portal.closeWithoutTimeout();
+    ok(!modal.portal.state.isOpen);
+    unmountModal();
+  });
+
   describe('should close on overlay click', function() {
     afterEach('Unmount modal', function() {
       unmountModal();


### PR DESCRIPTION
Continuation of the fix #134. Look at this PR (#134) for more information.

- added spec to validate the fix.
- commits were not squashed to preserve the commit made by @CompuIves.

Thanks, @CompuIves.