### PR TITLE
[fixed] Fixes issue#131 -  Drag doesn't close modal

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -128,7 +128,7 @@ var ModalPortal = module.exports = React.createClass({
     }
   },
 
-  handleOverlayClick: function(event) {
+  handleOverlayMouseDown: function(event) {
     var node = event.target
 
     while (node) {
@@ -166,6 +166,10 @@ var ModalPortal = module.exports = React.createClass({
     return additional ? className + ' ' + additional : className;
   },
 
+  stopPropagation: function(event) {
+    event.stopPropagation();
+  },
+
   render: function() {
     var contentStyles = (this.props.className) ? {} : this.props.defaultStyles.content;
     var overlayStyles = (this.props.overlayClassName) ? {} : this.props.defaultStyles.overlay;
@@ -175,14 +179,15 @@ var ModalPortal = module.exports = React.createClass({
         ref: "overlay",
         className: this.buildClassName('overlay', this.props.overlayClassName),
         style: Assign({}, overlayStyles, this.props.style.overlay || {}),
-        onClick: this.handleOverlayClick
+        onMouseDown: this.handleOverlayMouseDown
       },
         div({
           ref: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
           tabIndex: "-1",
-          onKeyDown: this.handleKeyDown
+          onKeyDown: this.handleKeyDown,
+          onMouseDown: this.stopPropagation
         },
           this.props.children
         )

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -245,7 +245,7 @@ describe('Modal', function () {
         ok(!requestCloseCallback.called)
       });
 
-      it('verify overlay click when shouldCloseOnOverlayClick sets to true', function() {
+      it('verify overlay mousedown when shouldCloseOnOverlayClick sets to true', function() {
         var requestCloseCallback = sinon.spy();
         var modal = renderModal({
           isOpen: true,
@@ -257,7 +257,7 @@ describe('Modal', function () {
         equal(modal.props.isOpen, true);
         var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         equal(overlay.length, 1);
-        Simulate.click(overlay[0]); // click the overlay
+        Simulate.mouseDown(overlay[0]); // click the overlay
         ok(requestCloseCallback.called)
       });
 
@@ -274,7 +274,7 @@ describe('Modal', function () {
       });
     });
 
-    it('verify event passing on overlay click', function() {
+    it('verify event passing on overlay mousedown', function() {
       var requestCloseCallback = sinon.spy();
       var modal = renderModal({
         isOpen: true,
@@ -284,7 +284,7 @@ describe('Modal', function () {
       equal(modal.props.isOpen, true);
       var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
       equal(overlay.length, 1);
-      Simulate.click(overlay[0]); // click the overlay
+      Simulate.mouseDown(overlay[0]); // click the overlay
       ok(requestCloseCallback.called)
       // Check if event is passed to onRequestClose callback.
       var event = requestCloseCallback.getCall(0).args[0];


### PR DESCRIPTION
Fixes #[131].

Changes proposed:
- Mouse drag from the content window to the overlay doesn't close the modal

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.