### PR TITLE
[fixed] Unable to tab through modal inputs (#198)

### DIFF
--- a/lib/helpers/tabbable.js
+++ b/lib/helpers/tabbable.js
@@ -20,7 +20,7 @@ function focusable(element, isTabIndexNotNaN) {
 }
 
 function hidden(el) {
-  return (el.offsetWidth <= 0 && el.offsetHeight <= 0) ||
+  return (el.offsetWidth < 0 && el.offsetHeight < 0) ||
     el.style.display === 'none';
 }
 


### PR DESCRIPTION
Fixes #198.

  -Due to the 'visible' function recursively traversing up the DOM tree
  and checking the offset width and heights of all parents to determine
  visibility, any inputs contained within a ReactPortal with an offset
  height and width of 0/0 will be considered untabbable.