### PR TITLE
[fixed] Unable to tab through modal inputs (#198)

### DIFF
--- a/lib/helpers/tabbable.js
+++ b/lib/helpers/tabbable.js
@@ -16,7 +16,7 @@ function focusable(element, isTabIndexNotNaN) {
     !element.disabled :
     "a" === nodeName ?
       element.href || isTabIndexNotNaN :
-      isTabIndexNotNaN) && visible(element);
+      isTabIndexNotNaN) || visible(element);
 }
 
 function hidden(el) {


### PR DESCRIPTION
Fixes #198.

  -Due to the 'visible' function recursively traversing up the DOM tree
  and checking the offset width and heights of all parents to determine
  visibility, any inputs contained within a ReactPortal with an offset
  height and width of 0/0 will be considered untabbable. I'm proposing 
  we make this visibility check an "OR"  since relying on a parents offset 
  height and width is unreliable since sometimes a parent element does 
  not wrap it's children depending on the applied styles.