### PR TITLE
[changed] Don't render div on dom when isOpen is false

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -30,6 +30,11 @@ describe('State', () => {
     expect(ReactDOM.findDOMNode(mcontent(modal))).toNotExist();
   });
 
+  it('doesn\'t render the portal if modal is closed', () => {
+    const modal = renderModal({}, 'hello');
+    expect(ReactDOM.findDOMNode(modal.portal)).toNotExist();
+  })
+
   it('has default props', () => {
     const node = document.createElement('div');
     Modal.setAppElement(document.createElement('div'));

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -216,7 +216,7 @@ export default class ModalPortal extends Component {
     const contentStyles = className ? {} : defaultStyles.content;
     const overlayStyles = overlayClassName ? {} : defaultStyles.overlay;
 
-    return this.shouldBeClosed() ? <div /> : (
+    return this.shouldBeClosed() ? null : (
       <div
         ref={this.setOverlayRef}
         className={this.buildClassName('overlay', overlayClassName)}


### PR DESCRIPTION
I noticed that when I wanted to animate the fadein of a modal it only worked for the first time. This was because the css animation of `ReactModal__Overlay--after-open` only works when a div is rendered for the first time. That's why I changed the logic to render nothing if there is no modal.
I'm aware that this can break a lot of things (like using a ref for `ReactModal`) for other people, so maybe we need to bump a major version if we want to have this.

Changes proposed:
- When not open, render `null` instead of `div`

Upgrade Path (for changed or removed APIs):
When you want to use a `ref` on `ReactModal` and use it after it's rendered, you will have to place the call to the `ref` in a `setTimeout` so it's accessible after it's rendered.

Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.

This allows users to add an animation for opening the modal.
