### PR TITLE
[added] ability to change default 'ReactModalPortal' class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ you can pass `className` and `overlayClassName` props to the Modal.  If you do
 this then none of the default styles will apply and you will have full control
 over styling via CSS.
 
+You can also pass a `portalClassName` to change the wrapper's class (*ReactModalPortal*).
+This doesn't affect styling as no styles are applied to this element by default.
 
 ### Overriding styles globally
 The default styles above are available on `Modal.defaultStyles`. Changes to this

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -30,6 +30,7 @@ var Modal = React.createClass({
       content: React.PropTypes.object,
       overlay: React.PropTypes.object
     }),
+    portalClassName: React.PropTypes.string,
     appElement: React.PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
@@ -41,6 +42,7 @@ var Modal = React.createClass({
   getDefaultProps: function () {
     return {
       isOpen: false,
+      portalClassName: 'ReactModalPortal',
       ariaHideApp: true,
       closeTimeoutMS: 0,
       shouldCloseOnOverlayClick: true
@@ -49,7 +51,7 @@ var Modal = React.createClass({
 
   componentDidMount: function() {
     this.node = document.createElement('div');
-    this.node.className = 'ReactModalPortal';
+    this.node.className = this.props.portalClassName;
     document.body.appendChild(this.node);
     this.renderPortal(this.props);
   },

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -107,6 +107,12 @@ describe('Modal', function () {
     equal(tabPrevented, true);
   });
 
+  it('supports portalClassName', function () {
+    var modal = renderModal({isOpen: true, portalClassName: 'myPortalClass'});
+    equal(modal.node.className, 'myPortalClass');
+    unmountModal();
+  });
+
   it('supports custom className', function() {
     var modal = renderModal({isOpen: true, className: 'myClass'});
     notEqual(modal.portal.refs.content.className.indexOf('myClass'), -1);


### PR DESCRIPTION
Changes proposed:
- new `portalClassName` prop to change the *ReactModalPortal* class.

~~Upgrade Path (for changed or removed APIs):~~


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] ~~If the commit message has [changed] or [removed], there is an upgrade path above.~~


_____________

Thanks for this project! 

What do you think about adding this?

I think this is useful because:
  - code can be cleaner when also using custom content and overlay classnames. If using *BEM* classes, it makes more sense to have a DOM like `.CustomModal > (.CustomModal-content + .CustomModal-overlay)` and not like `.ReactModalPortal > (.CustomModal-content + .CustomModal-overlay)`.
  - my current use case is opening a modal from a content-script in an browser extension. I want to be able to target the portal DOM element precisely in order to prevent conflicts with the page css.

Few questions on my side:

- I went with "portalClassName" but I'm not sure if this is really speaking to everyone.
- I added a brief sentence about the change in the README but didn't add anything in the examples. I figured the readme change would be enough, but let me know if you don't think so.