### PR TITLE
[changed] Removal of tabindex to Constructed Div.

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -181,7 +181,6 @@ var ModalPortal = module.exports = React.createClass({
           ref: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
-          tabIndex: "-1",
           onKeyDown: this.handleKeyDown
         },
           this.props.children


### PR DESCRIPTION
Fixes #211.

Changes proposed:
- The `tabindex` attribute wasn't allowing for the focus to be reassigned when the modal was rendered. 
- By removing it, it allowed for free reassigment of the activeElement within the dom. 

Upgrade Path (for changed or removed APIs):

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
