### PR TITLE
Close modal when mouseDown and MouseUp happen only on the overlay

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -21,6 +21,7 @@ var CLASS_NAMES = {
 var ModalPortal = module.exports = React.createClass({
 
   displayName: 'ModalPortal',
+  shouldClose: null,
 
   getDefaultProps: function() {
     return {
@@ -128,20 +129,28 @@ var ModalPortal = module.exports = React.createClass({
     }
   },
 
-  handleOverlayClick: function(event) {
-    var node = event.target
-
-    while (node) {
-      if (node === this.refs.content) return
-      node = node.parentNode
+  handleOverlayMouseDown: function(event) {
+    if (this.shouldClose === null) {
+      this.shouldClose = true;
     }
+  },
 
-    if (this.props.shouldCloseOnOverlayClick) {
+  handleOverlayMouseUp: function(event) {
+    if (this.shouldClose && this.props.shouldCloseOnOverlayClick) {
       if (this.ownerHandlesClose())
         this.requestClose(event);
       else
         this.focusContent();
     }
+    this.shouldClose = null;
+  },
+
+  handleContentMouseDown: function(event) {
+    this.shouldClose = false;
+  },
+
+  handleContentMouseUp: function(event) {
+    this.shouldClose = false;
   },
 
   requestClose: function(event) {
@@ -175,14 +184,17 @@ var ModalPortal = module.exports = React.createClass({
         ref: "overlay",
         className: this.buildClassName('overlay', this.props.overlayClassName),
         style: Assign({}, overlayStyles, this.props.style.overlay || {}),
-        onClick: this.handleOverlayClick
+        onMouseDown: this.handleOverlayMouseDown,
+        onMouseUp: this.handleOverlayMouseUp
       },
         div({
           ref: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
           tabIndex: "-1",
-          onKeyDown: this.handleKeyDown
+          onKeyDown: this.handleKeyDown,
+          onMouseDown: this.handleContentMouseDown,
+          onMouseUp: this.handleContentMouseUp
         },
           this.props.children
         )

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -247,7 +247,8 @@ describe('Modal', function () {
         equal(modal.props.isOpen, true);
         var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         equal(overlay.length, 1);
-        Simulate.click(overlay[0]); // click the overlay
+        Simulate.mouseDown(overlay[0]); // click the overlay
+        Simulate.mouseUp(overlay[0]);
         ok(!requestCloseCallback.called)
       });
 
@@ -263,8 +264,47 @@ describe('Modal', function () {
         equal(modal.props.isOpen, true);
         var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         equal(overlay.length, 1);
-        Simulate.click(overlay[0]); // click the overlay
+        Simulate.mouseDown(overlay[0]); // click the overlay
+        Simulate.mouseUp(overlay[0]);
         ok(requestCloseCallback.called)
+      });
+
+      it('verify overlay mouse down and content mouse up when shouldCloseOnOverlayClick sets to true', function() {
+        var requestCloseCallback = sinon.spy();
+        var modal = renderModal({
+                                  isOpen: true,
+                                  shouldCloseOnOverlayClick: true,
+                                  onRequestClose: function() {
+                                    requestCloseCallback();
+                                  }
+                                });
+        equal(modal.props.isOpen, true);
+        var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        var content = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
+        equal(overlay.length, 1);
+        equal(content.length, 1);
+        Simulate.mouseDown(overlay[0]); // click the overlay
+        Simulate.mouseUp(content[0]);
+        ok(!requestCloseCallback.called)
+      });
+
+      it('verify content mouse down and overlay mouse up when shouldCloseOnOverlayClick sets to true', function() {
+        var requestCloseCallback = sinon.spy();
+        var modal = renderModal({
+                                  isOpen: true,
+                                  shouldCloseOnOverlayClick: true,
+                                  onRequestClose: function() {
+                                    requestCloseCallback();
+                                  }
+                                });
+        equal(modal.props.isOpen, true);
+        var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        var content = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
+        equal(content.length, 1);
+        equal(overlay.length, 1);
+        Simulate.mouseDown(content[0]); // click the overlay
+        Simulate.mouseUp(overlay[0]);
+        ok(!requestCloseCallback.called)
       });
 
       it('should not stop event propagation', function() {
@@ -290,7 +330,8 @@ describe('Modal', function () {
       equal(modal.props.isOpen, true);
       var overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
       equal(overlay.length, 1);
-      Simulate.click(overlay[0]); // click the overlay
+      Simulate.mouseDown(overlay[0]); // click the overlay
+      Simulate.mouseUp(overlay[0]);
       ok(requestCloseCallback.called)
       // Check if event is passed to onRequestClose callback.
       var event = requestCloseCallback.getCall(0).args[0];


### PR DESCRIPTION
Changes proposed:
- If the user perform a mouse down and up only on the overlay: close the modal
- If the user perform a mouse down on the overlay, then a mouse up on the content: do nothing
- If the user perform a mouse down on the content, then a mouse up on the overlay: do nothing

Moreover, I tried to avoid the use of stopPropagation.

And it should also fix the [issue#131](https://github.com/reactjs/react-modal/issues/131) resolved by @abhijitkane in his [pull request](https://github.com/reactjs/react-modal/pull/197) by handling this problem with mouse down events only and stopPropagation.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

finally, I'm not really sure if it's a bug fix or not... :)