### PR TITLE
[fixed] Don't steal focus from a descendent when rendering

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -98,7 +98,10 @@ var ModalPortal = module.exports = React.createClass({
   },
 
   focusContent: function() {
-    this.refs.content.focus();
+    // Don't steal focus from inner elements
+    if (!this.contentHasFocus()) {
+      this.refs.content.focus();
+    }
   },
 
   closeWithTimeout: function() {
@@ -155,6 +158,10 @@ var ModalPortal = module.exports = React.createClass({
 
   shouldBeClosed: function() {
     return !this.props.isOpen && !this.state.beforeClose;
+  },
+
+  contentHasFocus() {
+    return document.activeElement === this.refs.content || this.refs.content.contains(document.activeElement);
   },
 
   buildClassName: function(which, additional) {

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -86,6 +86,14 @@ describe('Modal', function () {
     });
   });
 
+  it('does not focus the modal content when a descendent is already focused', function() {
+    var input = React.DOM.input({ className: 'focus_input', ref: function(el) { el && el.focus(); } });
+    renderModal({isOpen: true}, input, function () {
+      strictEqual(document.activeElement, document.querySelector('.focus_input'));
+      unmountModal();
+    });
+  });
+
   it('handles case when child has no tabbable elements', function() {
     var component = renderModal({isOpen: true}, 'hello');
     assert.doesNotThrow(function() {


### PR DESCRIPTION
Fixes #220.

Changes proposed:
- Before focusing on the content div, check to see that the currently focused element isn't a descendent of the content div, to respect any focusing the application may have already done.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

