### PR TITLE
[added] Apply custom data- and aria- props to content div

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var HTMLDOMPropertyConfig = require('react/lib/HTMLDOMPropertyConfig');
 var div = React.DOM.div;
 var focusManager = require('../helpers/focusManager');
 var scopeTab = require('../helpers/scopeTab');
@@ -17,6 +18,18 @@ var CLASS_NAMES = {
     beforeClose: 'ReactModal__Content--before-close'
   }
 };
+
+function getCustomProps(props) {
+  var customProps = {};
+
+  Object.keys(props).forEach(function (key) {
+    if (HTMLDOMPropertyConfig.isCustomAttribute(key)) {
+      customProps[key] = props[key];
+    }
+  });
+
+  return customProps;
+}
 
 var ModalPortal = module.exports = React.createClass({
 
@@ -194,7 +207,7 @@ var ModalPortal = module.exports = React.createClass({
         onMouseDown: this.handleOverlayMouseDown,
         onMouseUp: this.handleOverlayMouseUp
       },
-        div({
+        div(Assign(getCustomProps(this.props), {
           ref: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
@@ -203,7 +216,7 @@ var ModalPortal = module.exports = React.createClass({
           onMouseDown: this.handleContentMouseDown,
           onMouseUp: this.handleContentMouseUp,
           role: "dialog"
-        },
+        }),
           this.props.children
         )
       )

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -140,6 +140,18 @@ describe('Modal', function () {
     unmountModal();
   });
 
+  it('supports custom aria-attributes', function () {
+    var modal = renderModal({isOpen: true, 'aria-foo': 'bar'});
+    equal(modal.portal.refs.content.getAttribute('aria-foo'), 'bar');
+    unmountModal();
+  });
+
+  it('supports custom data-attributes', function () {
+    var modal = renderModal({isOpen: true, 'data-foo': 'bar'});
+    equal(modal.portal.refs.content.getAttribute('data-foo'), 'bar');
+    unmountModal();
+  });
+
   it('overrides the default styles when a custom classname is used', function () {
     var modal = renderModal({isOpen: true, className: 'myClass'});
     equal(modal.portal.refs.content.style.top, '');


### PR DESCRIPTION
Changes proposed:
- Apply `aria-*` and `data-*` props to the modal content div

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
