### PR TITLE
[added] [changed] made all classes customizable with a prop for each;…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ At this time, media queries will need to be handled by the consumer.
 If you prefer not to use inline styles or are unable to do so in your project,
 you can pass `className` and `overlayClassName` props to the Modal.  If you do
 this then none of the default styles will apply and you will have full control
-over styling via CSS.
+over styling via CSS. There will be other classes which will be added depending on the state of the modal, such as `--after-open` and `--before-close`. These classes will be prefixed with the class names passed as props or with the default class names, for example with a `className=mycompany-modal-class` will  produce a derivate class  `mycompany-modal-class--after-open`.
 
 You can also pass a `portalClassName` to change the wrapper's class (*ReactModalPortal*).
 This doesn't affect styling as no styles are applied to this element by default.
+
+In addition you can also pass `bodyClassName` which will be the base for the class added to the body of the document.
 
 ### Overriding styles globally
 The default styles above are available on `Modal.defaultStyles`. Changes to this

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -31,6 +31,7 @@ var Modal = React.createClass({
       overlay: React.PropTypes.object
     }),
     portalClassName: React.PropTypes.string,
+    bodyClassName: React.PropTypes.string,
     appElement: React.PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
@@ -43,6 +44,7 @@ var Modal = React.createClass({
     return {
       isOpen: false,
       portalClassName: 'ReactModalPortal',
+      bodyClassName: 'ReactModal__Body',
       ariaHideApp: true,
       closeTimeoutMS: 0,
       shouldCloseOnOverlayClick: true
@@ -63,14 +65,18 @@ var Modal = React.createClass({
   componentWillUnmount: function() {
     ReactDOM.unmountComponentAtNode(this.node);
     document.body.removeChild(this.node);
-    elementClass(document.body).remove('ReactModal__Body--open');
+    elementClass(document.body).remove(this.openBodyClass());
+  },
+
+  openBodyClass: function(){
+    return this.props.bodyClassName+"--open";
   },
 
   renderPortal: function(props) {
     if (props.isOpen) {
-      elementClass(document.body).add('ReactModal__Body--open');
+      elementClass(document.body).add(this.openBodyClass());
     } else {
-      elementClass(document.body).remove('ReactModal__Body--open');
+      elementClass(document.body).remove(this.openBodyClass());
     }
 
     if (props.ariaHideApp) {

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -4,32 +4,24 @@ var focusManager = require('../helpers/focusManager');
 var scopeTab = require('../helpers/scopeTab');
 var Assign = require('lodash.assign');
 
-// so that our CSS is statically analyzable
-var CLASS_NAMES = {
-  overlay: {
-    base: 'ReactModal__Overlay',
-    afterOpen: 'ReactModal__Overlay--after-open',
-    beforeClose: 'ReactModal__Overlay--before-close'
+var noOp = function(){};
+
+var defaultProps = {
+  onAfterClose: noOp,
+  style: {
+    overlay: {},
+    content: {}
   },
-  content: {
-    base: 'ReactModal__Content',
-    afterOpen: 'ReactModal__Content--after-open',
-    beforeClose: 'ReactModal__Content--before-close'
-  }
+  overlayClassName: 'ReactModal__Overlay',
+  className: 'ReactModal__Content'
 };
 
 var ModalPortal = module.exports = React.createClass({
-
   displayName: 'ModalPortal',
   shouldClose: null,
 
   getDefaultProps: function() {
-    return {
-      style: {
-        overlay: {},
-        content: {}
-      }
-    };
+    return defaultProps;
   },
 
   getInitialState: function() {
@@ -122,6 +114,7 @@ var ModalPortal = module.exports = React.createClass({
   afterClose: function() {
     focusManager.returnFocus();
     focusManager.teardownScopedFocus();
+    this.props.onAfterClose();
   },
 
   handleKeyDown: function(event) {
@@ -173,23 +166,23 @@ var ModalPortal = module.exports = React.createClass({
     return document.activeElement === this.refs.content || this.refs.content.contains(document.activeElement);
   },
 
-  buildClassName: function(which, additional) {
-    var className = CLASS_NAMES[which].base;
+  buildClassName: function(baseClass) {
+    var className = baseClass+" ";
     if (this.state.afterOpen)
-      className += ' '+CLASS_NAMES[which].afterOpen;
+      className += baseClass+'--after-open';
     if (this.state.beforeClose)
-      className += ' '+CLASS_NAMES[which].beforeClose;
-    return additional ? className + ' ' + additional : className;
+      className += baseClass+'--before-close';
+    return className;
   },
 
   render: function() {
-    var contentStyles = (this.props.className) ? {} : this.props.defaultStyles.content;
-    var overlayStyles = (this.props.overlayClassName) ? {} : this.props.defaultStyles.overlay;
+    var contentStyles = (this.props.className !== defaultProps.className) ? {} : this.props.defaultStyles.content;
+    var overlayStyles = (this.props.overlayClassName !== defaultProps.overlayClassName) ? {} : this.props.defaultStyles.overlay;
 
     return this.shouldBeClosed() ? div() : (
       div({
         ref: "overlay",
-        className: this.buildClassName('overlay', this.props.overlayClassName),
+        className: this.buildClassName(this.props.overlayClassName),
         style: Assign({}, overlayStyles, this.props.style.overlay || {}),
         onMouseDown: this.handleOverlayMouseDown,
         onMouseUp: this.handleOverlayMouseUp
@@ -197,7 +190,7 @@ var ModalPortal = module.exports = React.createClass({
         div({
           ref: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
-          className: this.buildClassName('content', this.props.className),
+          className: this.buildClassName(this.props.className),
           tabIndex: "-1",
           onKeyDown: this.handleKeyDown,
           onMouseDown: this.handleContentMouseDown,

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -10,6 +10,10 @@ var sinon = require('sinon');
 
 describe('Modal', function () {
 
+  afterEach(function() {
+    unmountModal();
+  });
+
   it('scopes tab navigation to the modal');
   it('focuses the last focused element when tabbing in from browser chrome');
 
@@ -17,13 +21,11 @@ describe('Modal', function () {
   it('can be open initially', function() {
     var component = renderModal({isOpen: true}, 'hello');
     equal(component.portal.refs.content.innerHTML.trim(), 'hello');
-    unmountModal();
   });
 
   it('can be closed initially', function() {
     var component = renderModal({}, 'hello');
     equal(ReactDOM.findDOMNode(component.portal).innerHTML.trim(), '');
-    unmountModal();
   });
 
   it('accepts appElement as a prop', function() {
@@ -55,14 +57,12 @@ describe('Modal', function () {
     var child = 'I am a child of Modal, and he has sent me here...';
     var component = renderModal({isOpen: true}, child);
     equal(component.portal.refs.content.innerHTML, child);
-    unmountModal();
   });
 
   it('renders the modal content with a dialog aria role ', function () {
     var child = 'I am a child of Modal, and he has sent me here...';
     var component = renderModal({isOpen: true}, child);
     equal(component.portal.refs.content.getAttribute('role'), 'dialog');
-    unmountModal();
   });
 
   it('has default props', function() {
@@ -89,7 +89,6 @@ describe('Modal', function () {
   it('focuses the modal content', function() {
     renderModal({isOpen: true}, null, function () {
       strictEqual(document.activeElement, this.portal.refs.content);
-      unmountModal();
     });
   });
 
@@ -97,7 +96,6 @@ describe('Modal', function () {
     var input = React.DOM.input({ className: 'focus_input', ref: function(el) { el && el.focus(); } });
     renderModal({isOpen: true}, input, function () {
       strictEqual(document.activeElement, document.querySelector('.focus_input'));
-      unmountModal();
     });
   });
 
@@ -106,7 +104,6 @@ describe('Modal', function () {
     assert.doesNotThrow(function() {
       Simulate.keyDown(component.portal.refs.content, {key: "Tab", keyCode: 9, which: 9})
     });
-    unmountModal();
   });
 
   it('keeps focus inside the modal when child has no tabbable elements', function() {
@@ -125,25 +122,36 @@ describe('Modal', function () {
   it('supports portalClassName', function () {
     var modal = renderModal({isOpen: true, portalClassName: 'myPortalClass'});
     equal(modal.node.className, 'myPortalClass');
-    unmountModal();
   });
 
+  function customClassTest(className, refName){
+    var props = {
+      isOpen: true,
+      [className]: 'myClass',
+      closeTimeoutMS: 2000,
+      onRequestClose: function() {}
+    };
+    var modal = renderModal(props);
+    var refClassName = function () {return modal.portal.refs[refName].className};
+    notEqual(refClassName().indexOf('myClass'), -1);
+    notEqual(refClassName().indexOf('myClass--after-open'), -1);
+    props.isOpen = false;
+    var modal = renderModal(props, null, function(){
+      notEqual(refClassName().indexOf('myClass--before-close'), -1);
+    });
+  }
+
   it('supports custom className', function() {
-    var modal = renderModal({isOpen: true, className: 'myClass'});
-    notEqual(modal.portal.refs.content.className.indexOf('myClass'), -1);
-    unmountModal();
+    customClassTest('className', 'content');
   });
 
   it('supports overlayClassName', function () {
-    var modal = renderModal({isOpen: true, overlayClassName: 'myOverlayClass'});
-    notEqual(modal.portal.refs.overlay.className.indexOf('myOverlayClass'), -1);
-    unmountModal();
+    customClassTest('overlayClassName', 'overlay');
   });
 
   it('overrides the default styles when a custom classname is used', function () {
     var modal = renderModal({isOpen: true, className: 'myClass'});
     equal(modal.portal.refs.content.style.top, '');
-    unmountModal();
   });
 
   it('overrides the default styles when a custom overlayClassName is used', function () {
@@ -181,23 +189,41 @@ describe('Modal', function () {
     Modal.defaultStyles.content.position = previousStyle
   });
 
+  function renderAndCheckBodyClassTest (className, props, hasClass) {
+    renderModal(props);
+    equal(document.body.className.indexOf(className) !== -1, hasClass);
+  }
+  function addsClassToBodyWhenOpenAndCloseTest(props, className) {
+    props.isOpen = false;
+    renderAndCheckBodyClassTest(className, props, false);
+
+    props.isOpen = true;
+    renderAndCheckBodyClassTest(className, props, true);
+
+    props.isOpen = false;
+    renderAndCheckBodyClassTest(className, props, false);
+  }
+
   it('adds class to body when open', function() {
-    var modal = renderModal({isOpen: false});
-    equal(document.body.className.indexOf('ReactModal__Body--open') !== -1, false);
-
-    modal = renderModal({isOpen: true});
-    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, true);
-
-    modal = renderModal({isOpen: false});
-    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, false);
-    unmountModal();
+    addsClassToBodyWhenOpenAndCloseTest({}, 'ReactModal__Body--open');
   });
 
-  it('removes class from body when unmounted without closing', function() {
-    var modal = renderModal({isOpen: true});
-    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, true);
+  function removesClassFromBodyWhenUnmountedWithoutClosingTest(props, className){
+    props.isOpen = true;
+    renderAndCheckBodyClassTest(className, props, true);
     unmountModal();
-    equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, false);
+    equal(document.body.className.indexOf(className)  !== -1, false);
+  }
+
+  it('removes class from body when unmounted without closing', function() {
+    removesClassFromBodyWhenUnmountedWithoutClosingTest({}, 'ReactModal__Body--open')
+  });
+
+  it('supports bodyClassName', function () {
+    var customClass = 'myBodyClass';
+    var props = {bodyClassName: customClass};
+    addsClassToBodyWhenOpenAndCloseTest(props, customClass+'--open');
+    removesClassFromBodyWhenUnmountedWithoutClosingTest(props, customClass+'--open')
   });
 
   it('adds --after-open for animations', function() {
@@ -206,7 +232,6 @@ describe('Modal', function () {
     var content = document.querySelector('.ReactModal__Content');
     ok(overlay.className.match(/ReactModal__Overlay--after-open/));
     ok(content.className.match(/ReactModal__Content--after-open/));
-    unmountModal();
   });
 
   it('should trigger the onAfterOpen callback', function() {
@@ -218,7 +243,6 @@ describe('Modal', function () {
       }
     });
     ok(afterOpenCallback.called);
-    unmountModal();
   });
 
   it('check the state of the modal after close with time out and reopen it', function() {
@@ -232,7 +256,6 @@ describe('Modal', function () {
     modal.portal.open();
     modal.portal.closeWithoutTimeout();
     ok(!modal.portal.state.isOpen);
-    unmountModal();
   });
 
   describe('should close on overlay click', function() {
@@ -375,26 +398,20 @@ describe('Modal', function () {
     equal(event.constructor.name, 'SyntheticEvent');
   });
 
-  //it('adds --before-close for animations', function() {
-    //var node = document.createElement('div');
+  it('adds --before-close for animations', function() {
+    var props = {
+      isOpen: true,
+      closeTimeoutMS: 2000,
+      onRequestClose: function() {}
+    };
+    var modal = renderModal(props);
 
-    //var component = ReactDOM.render(React.createElement(Modal, {
-      //isOpen: true,
-      //ariaHideApp: false,
-      //closeTimeoutMS: 50,
-    //}), node);
-
-    //component = ReactDOM.render(React.createElement(Modal, {
-      //isOpen: false,
-      //ariaHideApp: false,
-      //closeTimeoutMS: 50,
-    //}), node);
-
-    // It can't find these nodes, I didn't spend much time on this
-    //var overlay = document.querySelector('.ReactModal__Overlay');
-    //var content = document.querySelector('.ReactModal__Content');
-    //ok(overlay.className.match(/ReactModal__Overlay--before-close/));
-    //ok(content.className.match(/ReactModal__Content--before-close/));
-    //unmountModal();
-  //});
+    props.isOpen = false;
+    var modal = renderModal(props, null, function(){
+      var overlay = document.querySelector('.ReactModal__Overlay');
+      var content = document.querySelector('.ReactModal__Content');
+      ok(overlay.className.match(/ReactModal__Overlay--before-close/));
+      ok(content.className.match(/ReactModal__Content--before-close/));
+    });
+  });
 });

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -13,12 +13,20 @@ var _currentDiv = null;
 
 renderModal = function(props, children, callback) {
   props.ariaHideApp = false;
-  _currentDiv = document.createElement('div');
-  document.body.appendChild(_currentDiv);
+  if (_currentDiv === null){
+    _currentDiv = document.createElement('div');
+    document.body.appendChild(_currentDiv);
+  }
+  return ReactDOM.render(Modal(props, children), _currentDiv, callback);
+};
+
+rerenderModal = function(_currentDiv, props, children, callback) {
+  props.ariaHideApp = false;
   return ReactDOM.render(Modal(props, children), _currentDiv, callback);
 };
 
 unmountModal = function() {
+  if (_currentDiv === null) return;
   ReactDOM.unmountComponentAtNode(_currentDiv);
   document.body.removeChild(_currentDiv);
   _currentDiv = null;


### PR DESCRIPTION
Changes proposed:
- All class names can be customised, this is helpful for people who want to name space their classes.
- Derivate classes, `--after-open` and `--before-close`, use their base classes as a constructor.
- Specs: `renderModal` helper function now re renders the modal if it already exists, this made a commented spec pass, so it has been included; `unmountModal` is called after each spec, so not needed calls were removed.

Upgrade Path (for changed or removed APIs):
`--after-open` and `--before-close` derivate classes are now constructed from the passed prop base class name.
CSS style which is based on the old behaviour needs to update.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

UPDATE: It seems I have sneaked in an extra feature mentioned in issue #214. If the feature is wanted I can write a spec for it, if not I can remove it from the PR.
