### PR TITLE
[added] Add contentLabel prop to put aria-label on modal content

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install --save react-modal
   onRequestClose={requestCloseFn}
   closeTimeoutMS={n}
   style={customStyle}
+  contentLabel="Modal"
 >
   <h1>Modal Content</h1>
   <p>Etc.</p>
@@ -136,7 +137,9 @@ var App = React.createClass({
           isOpen={this.state.modalIsOpen}
           onAfterOpen={this.afterOpenModal}
           onRequestClose={this.closeModal}
-          style={customStyles} >
+          style={customStyles}
+          contentLabel="Example Modal"
+        >
 
           <h2 ref="subtitle">Hello</h2>
           <button onClick={this.closeModal}>close</button>
@@ -171,7 +174,9 @@ pass the 'shouldCloseOnOverlayClick' prop with 'false' value.
   onRequestClose={requestCloseFn}
   closeTimeoutMS={n}
   shouldCloseOnOverlayClick={false}
-  style={customStyle}>
+  style={customStyle}
+  contentLabel="No Overlay Click Modal"
+>
 
   <h1>Force Modal</h1>
   <p>Modal cannot be closed when clicking the overlay area</p>

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -37,7 +37,8 @@ var Modal = React.createClass({
     closeTimeoutMS: React.PropTypes.number,
     ariaHideApp: React.PropTypes.bool,
     shouldCloseOnOverlayClick: React.PropTypes.bool,
-    role: React.PropTypes.string
+    role: React.PropTypes.string,
+    contentLabel: React.PropTypes.string.isRequired
   },
 
   getDefaultProps: function () {

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -202,7 +202,8 @@ var ModalPortal = module.exports = React.createClass({
           onKeyDown: this.handleKeyDown,
           onMouseDown: this.handleContentMouseDown,
           onMouseUp: this.handleContentMouseUp,
-          role: this.props.role
+          role: this.props.role,
+          "aria-label": this.props.contentLabel
         },
           this.props.children
         )

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -65,6 +65,13 @@ describe('Modal', function () {
     unmountModal();
   });
 
+  it('renders the modal with a aria-label based on the contentLabel prop', function () {
+    var child = 'I am a child of Modal, and he has sent me here...';
+    var component = renderModal({isOpen: true, contentLabel: 'Special Modal'}, child);
+    equal(component.portal.refs.content.getAttribute('aria-label'), 'Special Modal');
+    unmountModal();
+  });
+
   it('has default props', function() {
     var node = document.createElement('div');
     Modal.setAppElement(document.createElement('div'));


### PR DESCRIPTION
Fixes #236.

Changes proposed:
- Add a aria-label to the modal content

Upgrade Path (for changed or removed APIs):
 - Existing modals should add a `contentLabel` prop describing the modal content


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.