### PR TITLE
[changed] replaced lodash assign for babel’s Object.assign polyfill

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -5,14 +5,14 @@ var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
 var elementClass = require('element-class');
 var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeIntoContainer;
-var Assign = require('lodash.assign');
-
+var Assign = require('../helpers/assign');
 var SafeHTMLElement = ExecutionEnvironment.canUseDOM ? window.HTMLElement : {};
 var AppElement = ExecutionEnvironment.canUseDOM ? document.body : {appendChild: function() {}};
 
 var Modal = React.createClass({
 
   displayName: 'Modal',
+  openBodyClass: "ReactModal__Body--open",
   statics: {
     setAppElement: function(element) {
         AppElement = ariaAppHider.setElement(element);
@@ -64,21 +64,22 @@ var Modal = React.createClass({
   componentWillUnmount: function() {
     ReactDOM.unmountComponentAtNode(this.node);
     document.body.removeChild(this.node);
-    elementClass(document.body).remove('ReactModal__Body--open');
+    elementClass(document.body).remove(this.openBodyClass);
   },
 
   renderPortal: function(props) {
     if (props.isOpen) {
-      elementClass(document.body).add('ReactModal__Body--open');
+      elementClass(document.body).add(this.openBodyClass);
     } else {
-      elementClass(document.body).remove('ReactModal__Body--open');
+      elementClass(document.body).remove(this.openBodyClass);
     }
 
     if (props.ariaHideApp) {
       ariaAppHider.toggle(props.isOpen, props.appElement);
     }
 
-    this.portal = renderSubtreeIntoContainer(this, ModalPortal(Assign({}, props, {defaultStyles: Modal.defaultStyles})), this.node);
+    var passedProps = Assign({}, props, {defaultStyles: Modal.defaultStyles});
+    this.portal = renderSubtreeIntoContainer(this, ModalPortal(passedProps), this.node);
   },
 
   render: function () {

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -2,7 +2,7 @@ var React = require('react');
 var div = React.DOM.div;
 var focusManager = require('../helpers/focusManager');
 var scopeTab = require('../helpers/scopeTab');
-var Assign = require('lodash.assign');
+var Assign = require('../helpers/assign');
 
 // so that our CSS is statically analyzable
 var CLASS_NAMES = {
@@ -183,20 +183,20 @@ var ModalPortal = module.exports = React.createClass({
   },
 
   render: function() {
-    var contentStyles = (this.props.className) ? {} : this.props.defaultStyles.content;
-    var overlayStyles = (this.props.overlayClassName) ? {} : this.props.defaultStyles.overlay;
+    var defaultContentStyles = (this.props.className) ? {} : this.props.defaultStyles.content;
+    var defaultOverlayStyles = (this.props.overlayClassName) ? {} : this.props.defaultStyles.overlay;
 
     return this.shouldBeClosed() ? div() : (
       div({
         ref: "overlay",
         className: this.buildClassName('overlay', this.props.overlayClassName),
-        style: Assign({}, overlayStyles, this.props.style.overlay || {}),
+        style: Assign({}, defaultOverlayStyles, this.props.style.overlay || {}),
         onMouseDown: this.handleOverlayMouseDown,
         onMouseUp: this.handleOverlayMouseUp
       },
         div({
           ref: "content",
-          style: Assign({}, contentStyles, this.props.style.content || {}),
+          style: Assign({}, defaultContentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
           tabIndex: "-1",
           onKeyDown: this.handleKeyDown,

--- a/lib/helpers/assign.js
+++ b/lib/helpers/assign.js
@@ -1,0 +1,16 @@
+//adapted from babel transpiler assign polyfill
+var babelAssign = function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
+
+var _extends = Object.assign || babelAssign;
+
+module.exports = _extends;

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "dependencies": {
     "element-class": "^0.2.0",
-    "exenv": "1.2.0",
-    "lodash.assign": "^3.2.0"
+    "exenv": "1.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Fixes #238.

Changes proposed:
- Replaced lodash assign in favour of a polyfill from babel's transpiler
- Minor drying up of code
- Small variable name change

File size benchmarking of minified dist:
- With babel's object assign: 10KB
- With sindresorhus/object-assign: 11KB
- With lodash assign: 15KB

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
