### PR TITLE
Document ReactModal__Body--open so people dare to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ This doesn't affect styling as no styles are applied to this element by default.
 The default styles above are available on `Modal.defaultStyles`. Changes to this
 object will apply to all instances of the modal.
 
+### Body class
+When the modal is opened a `ReactModal__Body--open` class is added to the `body` tag.
+You can use this to remove scrolling on the the body while the modal is open.
+
+```CSS
+/* Remove scroll on the body when react-modal is open */
+.ReactModal__Body--open {
+    overflow: hidden;
+}
+```
+
 ## Examples
 Inside an app:
 


### PR DESCRIPTION
Changes proposed:
- document the `ReactModal__Body--open` so people dare to use it (with a body scroll example)

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

