### PR TITLE
[fixed] respect closeTimeoutMS during unmount

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -105,6 +105,24 @@ export default class Modal extends Component {
       ariaAppHider.show(this.props.appElement);
     }
 
+    const state = this.portal.state;
+    const now = Date.now();
+    const closesAt = state.isOpen && this.props.closeTimeoutMS
+      && (state.closesAt
+        || now + this.props.closeTimeoutMS);
+
+    if (closesAt) {
+      if (!state.beforeClose) {
+        this.portal.closeWithTimeout();
+      }
+
+      setTimeout(this.removePortal.bind(this), closesAt - now);
+    } else {
+      this.removePortal();
+    }
+  }
+
+  removePortal () {
     ReactDOM.unmountComponentAtNode(this.node);
     const parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -132,8 +132,9 @@ export default class ModalPortal extends Component {
   }
 
   closeWithTimeout () {
-    this.setState({ beforeClose: true }, () => {
-      this.closeTimer = setTimeout(this.closeWithoutTimeout, this.props.closeTimeoutMS);
+    const closesAt = Date.now() + this.props.closeTimeoutMS;
+    this.setState({ beforeClose: true, closesAt }, () => {
+      this.closeTimer = setTimeout(this.closeWithoutTimeout, this.state.closesAt - Date.now());
     });
   }
 
@@ -142,7 +143,8 @@ export default class ModalPortal extends Component {
       beforeClose: false,
       isOpen: false,
       afterOpen: false,
-    }, () => this.afterClose());
+      closesAt: null
+    }, this.afterClose);
   }
 
   handleKeyDown = (event) => {
@@ -182,7 +184,7 @@ export default class ModalPortal extends Component {
   }
 
   shouldBeClosed () {
-    return !this.props.isOpen && !this.state.beforeClose;
+    return !this.state.isOpen && !this.state.beforeClose;
   }
 
   contentHasFocus () {


### PR DESCRIPTION
Fixes #17.

Changes proposed:
- wait before unmounting the portal if `closeTimeoutMS` is set
- full details in commit message

Upgrade Path (for changed or removed APIs):
- The upgrade path is to undo any workarounds or hacks (e.g. manually triggering the close animation before unmounting the `Modal`), though due to the lack of activity on the referenced issue, I'm guessing most users won't be affected?

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
