### PR TITLE
Ensure aria-hidden on appElement is reset on unmount

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -63,6 +63,10 @@ var Modal = React.createClass({
   },
 
   componentWillUnmount: function() {
+    if (this.props.ariaHideApp) {
+      ariaAppHider.show(this.props.appElement);
+    }
+
     ReactDOM.unmountComponentAtNode(this.node);
     document.body.removeChild(this.node);
     elementClass(document.body).remove('ReactModal__Body--open');

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -207,6 +207,18 @@ describe('Modal', function () {
     equal(document.body.className.indexOf('ReactModal__Body--open')  !== -1, false);
   });
 
+  it('removes aria-hidden from appElement when unmounted without closing', function() {
+    var el = document.createElement('div');
+    var node = document.createElement('div');
+    ReactDOM.render(React.createElement(Modal, {
+      isOpen: true,
+      appElement: el
+    }), node);
+    equal(el.getAttribute('aria-hidden'), 'true');
+    ReactDOM.unmountComponentAtNode(node);
+    equal(el.getAttribute('aria-hidden'), null);
+  });
+
   it('adds --after-open for animations', function() {
     var modal = renderModal({isOpen: true});
     var overlay = document.querySelector('.ReactModal__Overlay');


### PR DESCRIPTION
Changes proposed:
- Reset `aria-hidden` on appElement when modal is unmounted without closing
