### PR TITLE
[added]Provide a hook to enable infinite scroll in modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ You can use this to remove scrolling on the the body while the modal is open.
 }
 ```
 
+### Provide an infinite scroll hook
+You can provide a callback function to be invoked when a user scroll down to
+the end of the modal. Provide `onEndReached` (function) and `onEndReachedThreshold` (number) via props.
+`onEndReached` will be called when modal has been scrolled within onEndReachedThreshold
+of the bottom.
+`onEndReachedThreshold` is threshold in pixel for calling `onEndReached`, defaults to 20.
+
+```jsx
+  <Modal
+    isOpen={bool}
+    onAfterOpen={afterOpenFn}
+    onRequestClose={requestCloseFn}
+    closeTimeoutMS={n}
+    style={customStyle}
+    contentLabel="Modal"
+    onEndReached={() => {console.log('fetch more resource!')}}
+    onEndReachedThreshold={30}
+  >
+    <h1>Modal Content</h1>
+    <p>Etc.</p>
+  </Modal>
+```
+
 ## Examples
 Inside an app:
 

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -47,7 +47,9 @@ var Modal = React.createClass({
       portalClassName: 'ReactModalPortal',
       ariaHideApp: true,
       closeTimeoutMS: 0,
-      shouldCloseOnOverlayClick: true
+      shouldCloseOnOverlayClick: true,
+      onEndReached: function() {},
+      onEndReachedThreshold: 20,
     };
   },
 

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -156,6 +156,13 @@ var ModalPortal = module.exports = React.createClass({
     this.shouldClose = false;
   },
 
+  handleContentScroll: function(event) {
+    const { scrollTop, scrollHeight, clientHeight } = this.refs.content;
+    if (scrollHeight - scrollTop <= clientHeight + this.props.onEndReachedThreshold) {
+      this.props.onEndReached();
+    }
+  },
+
   requestClose: function(event) {
     if (this.ownerHandlesClose())
       this.props.onRequestClose(event);
@@ -202,6 +209,7 @@ var ModalPortal = module.exports = React.createClass({
           onKeyDown: this.handleKeyDown,
           onMouseDown: this.handleContentMouseDown,
           onMouseUp: this.handleContentMouseUp,
+          onScroll: this.handleContentScroll,
           role: this.props.role,
           "aria-label": this.props.contentLabel
         },


### PR DESCRIPTION
I was trying to implement a infinite scroll feature within the modal using this library. I soon discovered that I had to fork the repo and make changes to let me provide a callback on scroll event. I was successful in implementing the feature after making the changes and thought it would be useful to have the same hook in the original library. 

It would be useful when you are trying to implement a modal to display a list of users (followers, people liked a post, etc..) and need to fetch more resource as you scroll down inside the modal. 

Changes proposed:
- Add two props `onEndReached` and `onEndReachedThreshold` to let user provide a callback function when bottom of the modal is reached.
- This provides a hook to enable infinite scroll feature inside the modal
