### PR TITLE
[fixed] hidden check to read `getClientBoundingRect` instead of `offset`

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -51,6 +51,9 @@ var App = React.createClass({
           <form>
             <input onChange={this.handleInputChange} />
             <input />
+            <span>
+              <input />
+            </span>
             <input />
             <input />
             <input />

--- a/lib/helpers/tabbable.js
+++ b/lib/helpers/tabbable.js
@@ -20,8 +20,14 @@ function focusable(element, isTabIndexNotNaN) {
 }
 
 function hidden(el) {
-  return (el.offsetWidth <= 0 && el.offsetHeight <= 0) ||
-    el.style.display === 'none';
+  if (el.style.display === 'none') return true;
+
+  // if we don't have this method we can't tell if it actually is hidden
+  // so default to NOT hidden
+  if (!el.getBoundingClientRect) return false;
+  var rect = el.getBoundingClientRect();
+
+  return (rect.height === 0 && rect.width === 0);
 }
 
 function visible(element) {

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -127,6 +127,51 @@ describe('Modal', function () {
         preventDefault: function() { tabPrevented = true; }
     });
     equal(tabPrevented, true);
+    unmountModal();
+  });
+
+  it('focuses first tabbable element on first tab press', function() {
+    var input = React.DOM.input({
+        className: 'input'
+      }
+    );
+
+    var modal = renderModal({isOpen: true}, input);
+
+    Simulate.keyDown(modal.portal.refs.content, {
+      key: "Tab",
+      keyCode: 9,
+      which: 9
+    });
+
+    strictEqual(document.activeElement, document.querySelector('.input'));
+
+    unmountModal();
+  });
+
+  it('focuses tabbable elements inside of inline elements', function() {
+    var visibleInputWrapper = React.DOM.span({
+      key: 'visible_input_wrapper',
+      className: 'visible_input_wrapper',
+    }, React.DOM.input({
+        className: 'visible_input',
+        style: {
+          display: 'block'
+        }
+      })
+    );
+
+    var modal = renderModal({isOpen: true}, visibleInputWrapper);
+
+    Simulate.keyDown(modal.portal.refs.content, {
+      key: "Tab",
+      keyCode: 9,
+      which: 9
+    });
+
+    strictEqual(document.activeElement, document.querySelector('.visible_input'));
+
+    unmountModal();
   });
 
   it('supports portalClassName', function () {


### PR DESCRIPTION
Fixes #224.

Changes proposed:
- Includes code change from #224
- Adds tests to that were requested by @claydiffrient: https://github.com/reactjs/react-modal/pull/224#issuecomment-252405710
- Adds example of tabbable element inside of an `inline` element

Upgrade Path (for changed or removed APIs): *none*

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
