### PR TITLE
[fixed] Respect overflow css property when determining whether or not a tabbable node is hidden

### DIFF
--- a/specs/Modal.helpers.spec.js
+++ b/specs/Modal.helpers.spec.js
@@ -1,0 +1,110 @@
+/* eslint-env mocha */
+import "should";
+import tabbable from "../src/helpers/tabbable";
+import "sinon";
+
+export default () => {
+  describe("tabbable", () => {
+    describe("without tabbable descendents", () => {
+      it("returns an empty array", () => {
+        const elem = document.createElement("div");
+        tabbable(elem).should.deepEqual([]);
+      });
+    });
+
+    describe("with tabbable descendents", () => {
+      let elem;
+      beforeEach(() => {
+        elem = document.createElement("div");
+        document.body.appendChild(elem);
+      });
+
+      afterEach(() => {
+        document.body.removeChild(elem);
+      });
+
+      it("includes descendent tabbable inputs", () => {
+        const input = document.createElement("input");
+        elem.appendChild(input);
+        tabbable(elem).should.containEql(input);
+      });
+
+      it("includes tabbable non-input elements", () => {
+        const div = document.createElement("div");
+        div.tabIndex = 1;
+        elem.appendChild(div);
+        tabbable(elem).should.containEql(div);
+      });
+
+      it("includes links with an href", () => {
+        const a = document.createElement("a");
+        a.href = "foobar";
+        a.innerHTML = "link";
+        elem.appendChild(a);
+        tabbable(elem).should.containEql(a);
+      });
+
+      it("excludes links without an href or a tabindex", () => {
+        const a = document.createElement("a");
+        elem.appendChild(a);
+        tabbable(elem).should.not.containEql(a);
+      });
+
+      it("excludes descendent inputs if they are not tabbable", () => {
+        const input = document.createElement("input");
+        input.tabIndex = -1;
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("excludes descendent inputs if they are disabled", () => {
+        const input = document.createElement("input");
+        input.disabled = true;
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("excludes descendent inputs if they are not displayed", () => {
+        const input = document.createElement("input");
+        input.style.display = "none";
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("excludes descendent inputs with 0 width and height", () => {
+        const input = document.createElement("input");
+        input.style.width = "0";
+        input.style.height = "0";
+        input.style.border = "0";
+        input.style.padding = "0";
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("excludes descendents with hidden parents", () => {
+        const input = document.createElement("input");
+        elem.style.display = "none";
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("excludes inputs with parents that have zero width and height", () => {
+        const input = document.createElement("input");
+        elem.style.width = "0";
+        elem.style.height = "0";
+        elem.style.overflow = "hidden";
+        elem.appendChild(input);
+        tabbable(elem).should.not.containEql(input);
+      });
+
+      it("includes inputs visible because of overflow == visible", () => {
+        const input = document.createElement("input");
+        elem.style.width = "0";
+        elem.style.height = "0";
+        elem.style.overflow = "visible";
+        elem.appendChild(input);
+        tabbable(elem).should.containEql(input);
+      });
+    });
+  });
+};

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-import "should";
 import should from "should";
 import React, { Component } from "react";
 import ReactDOM from "react-dom";

--- a/specs/index.js
+++ b/specs/index.js
@@ -3,7 +3,9 @@
 import ModalState from "./Modal.spec";
 import ModalEvents from "./Modal.events.spec";
 import ModalStyle from "./Modal.style.spec";
+import ModalHelpers from "./Modal.helpers.spec";
 
 describe("State", ModalState);
 describe("Style", ModalStyle);
 describe("Events", ModalEvents);
+describe("Helpers", ModalHelpers);

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -12,17 +12,24 @@
 
 const tabbableNode = /input|select|textarea|button|object/;
 
-function hidden(el) {
-  return (
-    (el.offsetWidth <= 0 && el.offsetHeight <= 0) || el.style.display === "none"
-  );
+function hidesContents(element) {
+  const zeroSize = element.offsetWidth <= 0 && element.offsetHeight <= 0;
+
+  // If the node is empty, this is good enough
+  if (zeroSize && !element.innerHTML) return true;
+
+  // Otherwise we need to check some styles
+  const style = window.getComputedStyle(element);
+  return zeroSize
+    ? style.getPropertyValue("overflow") !== "visible"
+    : style.getPropertyValue("display") == "none";
 }
 
 function visible(element) {
   let parentElement = element;
   while (parentElement) {
     if (parentElement === document.body) break;
-    if (hidden(parentElement)) return false;
+    if (hidesContents(parentElement)) return false;
     parentElement = parentElement.parentNode;
   }
   return true;


### PR DESCRIPTION
Fixes #211.

Changes proposed:
When checking whether or not a node is hidden, we traverse up through the body element and say "Hey, if this element is 0x0, then it is hidden. Don't allow tabbing to its descendant." But if I, for example, position an element absolutely from its parent, theres a good chance that parent may collapse to 0x0. And if that parent has an overflow of 'visible', my input element is still visible and should be tabbable.

In our case it was `.ReactModalPortal` that was collapsing down to 0x0 and failing the `tabbable` check because it was considered `hidden`, even though our modal was visible. In this case, tabbing within a modal had no effect, as everything was descendent from the portal. My guess is most of the struggles people are having with tabbing come from a similar setup. **As a work-around you can fix tabbing by setting the width or height of your collapsed parent element(s) to 1px**

I've fixed this by changing the check from `hidden` to `hidesContents`, and altered it to respect the `overflow` property when the node has contents.

I've also gone ahead and added testing for the entire `tabbable` helper.

Upgrade Path (for changed or removed APIs): n/a


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
