### PR TITLE
Fixes ReferenceError: document is not defined

### DIFF
--- a/lib/helpers/ariaAppHider.js
+++ b/lib/helpers/ariaAppHider.js
@@ -1,7 +1,7 @@
 var _element = typeof document !== 'undefined' ? document.body : null;
 
 function setElement(element) {
-  if (typeof element === 'string') {
+  if (typeof document !== 'undefined' && typeof element === 'string') {
     var el = document.querySelectorAll(element);
     element = 'length' in el ? el[0] : el;
   }


### PR DESCRIPTION
Fixes #272

ReferenceError: document is not defined

ariaAppHider.js:5 Object.setElement
[frontend]/[react-responsive-ui]/node_modules/react-modal/lib/helpers/ariaAppHider.js