### PR TITLE
added required props info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ npm install --save react-modal
 
 ## Usage
 
+The Modal object has two required props:
+
+- `isOpen` to render its children.
+- `contentLabel` to improve a11y, since `v1.6.0`.
+
+Example:
+
 ```xml
 <Modal
   isOpen={bool}


### PR DESCRIPTION
To accommodate the change in `v1.6.0`, I'd recommend to add required props info to README so that people will have it adapted beforehand.