### PR TITLE
[fixed] closeTimeoutMS doesn't work without onRequestClose

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -90,8 +90,6 @@ var ModalPortal = module.exports = React.createClass({
   },
 
   close: function() {
-    if (!this.ownerHandlesClose())
-      return;
     if (this.props.closeTimeoutMS > 0)
       this.closeWithTimeout();
     else


### PR DESCRIPTION
**Fixes #93** 

**Changes proposed:**
I have no idea why we have to use closeTimeoutMS together with onRequestClose.

**Acceptance Checklist:**
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

