### PR TITLE
[added] Add Overlay Extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example:
 ```
 
 ## Styles
-Styles are passed as an object with 2 keys, 'overlay' and 'content' like so
+Styles are passed as an object with 3 keys, 'overlay', 'content', 'extras' like so
 ```js
 {
   overlay : {
@@ -58,7 +58,11 @@ Styles are passed as an object with 2 keys, 'overlay' and 'content' like so
     borderRadius               : '4px',
     outline                    : 'none',
     padding                    : '20px'
-
+  },
+  extras: {
+    position : 'absolute',
+    bottom   : '10px',
+    right    : '10px'
   }
 }
 ```
@@ -69,8 +73,8 @@ At this time, media queries will need to be handled by the consumer.
 ### Using CSS Classes
 
 If you prefer not to use inline styles or are unable to do so in your project,
-you can pass `className` and `overlayClassName` props to the Modal.  If you do
-this then none of the default styles will apply and you will have full control
+you can pass `className`, `overlayClassName`, `overlayExtrasClassName` props to the Modal.  
+If you do this then none of the default styles will apply and you will have full control
 over styling via CSS.
 
 You can also pass a `portalClassName` to change the wrapper's class (*ReactModalPortal*).

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -42,6 +42,9 @@ var App = React.createClass({
         <Modal
           ref="mymodal"
           closeTimeoutMS={150}
+          overlayExtras={
+            <span style={{fontSize: '10px'}}>https://github.com/reactjs/react-modal</span>
+          }
           isOpen={this.state.modalIsOpen}
           onAfterOpen={this.handleOnAfterOpenModal}
           onRequestClose={this.handleModalCloseRequest}>

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -43,7 +43,9 @@ var Modal = React.createClass({
     shouldCloseOnOverlayClick: React.PropTypes.bool,
     parentSelector: React.PropTypes.func,
     role: React.PropTypes.string,
-    contentLabel: React.PropTypes.string.isRequired
+    contentLabel: React.PropTypes.string.isRequired,
+    overlayExtras: React.PropTypes.node,
+    overlayExtrasClassName: React.PropTypes.string
   },
 
   getDefaultProps: function () {
@@ -130,6 +132,11 @@ Modal.defaultStyles = {
     borderRadius            : '4px',
     outline                 : 'none',
     padding                 : '20px'
+  },
+  extras: {
+    position : 'absolute',
+    bottom   : '10px',
+    right    : '10px'
   }
 }
 

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -15,6 +15,11 @@ var CLASS_NAMES = {
     base: 'ReactModal__Content',
     afterOpen: 'ReactModal__Content--after-open',
     beforeClose: 'ReactModal__Content--before-close'
+  },
+  extras: {
+    base: 'ReactModal__OverlayExtras',
+    afterOpen: 'ReactModal__OverlayExtras--after-open',
+    beforeClose: 'ReactModal__OverlayExtras--before-close'
   }
 };
 
@@ -27,7 +32,8 @@ var ModalPortal = module.exports = React.createClass({
     return {
       style: {
         overlay: {},
-        content: {}
+        content: {},
+        extras:  {}
       }
     };
   },
@@ -183,6 +189,7 @@ var ModalPortal = module.exports = React.createClass({
   render: function() {
     var contentStyles = (this.props.className) ? {} : this.props.defaultStyles.content;
     var overlayStyles = (this.props.overlayClassName) ? {} : this.props.defaultStyles.overlay;
+    var extrasStyles = (this.props.overlayExtrasClassName) ? {} : this.props.defaultStyles.extras;
 
     return this.shouldBeClosed() ? div() : (
       div({
@@ -192,8 +199,10 @@ var ModalPortal = module.exports = React.createClass({
         onMouseDown: this.handleOverlayMouseDown,
         onMouseUp: this.handleOverlayMouseUp
       },
+      [
         div({
           ref: "content",
+          key: "content",
           style: Assign({}, contentStyles, this.props.style.content || {}),
           className: this.buildClassName('content', this.props.className),
           tabIndex: "-1",
@@ -203,8 +212,17 @@ var ModalPortal = module.exports = React.createClass({
           role: this.props.role,
           "aria-label": this.props.contentLabel
         },
-          this.props.children
+        this.props.children
+        ),
+        div({
+          ref: "extras",
+          key: "extras",
+          style: Assign({}, extrasStyles, this.props.style.extras || {}),
+          className: this.buildClassName('extras', this.props.overlayExtrasClassName)
+        },
+        this.props.overlayExtras
         )
+      ]
       )
     );
   }

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -416,4 +416,36 @@ describe('Modal', function () {
     //ok(content.className.match(/ReactModal__Content--before-close/));
     //unmountModal();
   //});
+
+  it('renders overlayExtras elements', function() {
+    var overlayExtras = 'I am a child of Overlay, and he has sent me here...';
+    var component = renderModal({isOpen: true, overlayExtras});
+    // console.log('Overlay: ', component.portal.refs.overlay.children[1].innerHTML);
+    equal(component.portal.refs.overlay.children.length, 2);
+    equal(component.portal.refs.overlay.children[1].innerHTML, overlayExtras);
+    unmountModal();
+  });
+
+  it('supports overlayExtrasClassName', function () {
+    var overlayExtrasClassName = 'myExtrasClass';
+    var modal = renderModal({isOpen: true, overlayExtrasClassName });
+    notEqual(modal.portal.refs.extras.className.indexOf(overlayExtrasClassName), -1);
+    unmountModal();
+  });
+
+  it('overrides the default styles when a custom overlayExtrasClassName is used', function () {
+    var overlayExtrasClassName = 'myExtrasClass';
+    var modal = renderModal({isOpen: true, overlayExtrasClassName });
+    equal(modal.portal.refs.extras.style.bottom, '');
+  });
+
+  it('supports adding style on the modal overlay extras', function() {
+    var modal = renderModal({isOpen: true, style: {extras: {width: '75px'}}});
+    equal(modal.portal.refs.extras.style.width, '75px');
+  });
+
+  it('supports overriding style on the modal contents extras', function() {
+    var modal = renderModal({isOpen: true, style: {extras: {position: 'static'}}});
+    equal(modal.portal.refs.extras.style.position, 'static');
+  });
 });


### PR DESCRIPTION
I have a use case where some text should be placed in bottom right corner of screen just below modal.
To have that text positioned relative to modal one can place it into modal itself, but to position text relative to screen it should be inside overlay.
Extras allows users to have some additional components inside modal overlay.

Changes proposed:
- Add `overlayExtras` prop allowing users to have additional elements inside modal overlay (e.g. info message, link, copyright)
- Add `overlayExtrasClassName` prop allowing to style extras div
- Add `styles.extras` prop (along with default values) allowing to style extras div
- Add extras example to basic examples

Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.

