### PR TITLE
[fixed] Add file extention to entry point for TypeScript importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-modal",
   "version": "1.6.4",
   "description": "Accessible modal dialog component for React.JS",
-  "main": "./lib/index",
+  "main": "./lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/reactjs/react-modal.git"


### PR DESCRIPTION
Though this is not react-modal library's problem, here is a tweak fix necessary for TypeScript project.

Please see below post for more details:

http://stackoverflow.com/questions/41077055/typescript-2-1-feature-of-implicit-import-not-working

FYI

"Untyped imports" Section:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html

```ts
// Succeeds if `node_modules/asdf/index.js` exists
import { x } from "asdf";
```

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
