### PR TITLE
Fix an example

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -1,6 +1,6 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var Modal = require('../../lib/index');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Modal from '../../lib/index';
 
 var appElement = document.getElementById('example');
 

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -137,7 +137,7 @@ export default class ModalPortal extends Component {
     });
   }
 
-  closeWithoutTimeout () {
+  closeWithoutTimeout = () => {
     this.setState({
       beforeClose: false,
       isOpen: false,


### PR DESCRIPTION
Changes proposed:
- Make use of es6 modules
https://github.com/reactjs/react-modal/pull/296/commits/959ec21d0ff0dcabaa712702bebe479e8cb932ee
<img width="470" alt="2017-01-01 19 58 27" src="https://cloud.githubusercontent.com/assets/3367801/21580962/b09ae19e-d05d-11e6-9890-d138396538b1.png">
We change to use es6 modules or rewrite it to `require('../../lib/index').defalut`.

I think it would be better to use es6 modules.

- Fix `this` scope
https://github.com/reactjs/react-modal/pull/296/commits/262e40d8b1c819d7833b95cd1b212091bce16838
<img width="415" alt="2017-01-01 19 59 04" src="https://cloud.githubusercontent.com/assets/3367801/21580970/3661383c-d05e-11e6-91fc-678751b63b82.png">


Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
