### PR TITLE
Get rid of CommonJS module

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import ExecutionEnvironment from 'exenv';
 import elementClass from 'element-class';
 import ModalPortal from './ModalPortal';
-import ariaAppHider from '../helpers/ariaAppHider';
+import * as ariaAppHider from '../helpers/ariaAppHider';
 
 const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
 

--- a/lib/helpers/ariaAppHider.js
+++ b/lib/helpers/ariaAppHider.js
@@ -1,6 +1,12 @@
 let globalElement = typeof document !== 'undefined' ? document.body : null;
 
-function setElement (element) {
+function validateElement (appElement) {
+  if (!appElement && !globalElement) {
+    throw new Error('react-modal: You must set an element with `Modal.setAppElement(el)` to make this accessible');
+  }
+}
+
+export function setElement (element) {
   let newElement = element;
   if (typeof newElement === 'string') {
     const el = document.querySelectorAll(element);
@@ -10,34 +16,22 @@ function setElement (element) {
   return globalElement;
 }
 
-function validateElement (appElement) {
-  if (!appElement && !globalElement) {
-    throw new Error('react-modal: You must set an element with `Modal.setAppElement(el)` to make this accessible');
-  }
-}
-
-function hide (appElement) {
+export function hide (appElement) {
   validateElement(appElement);
   (appElement || globalElement).setAttribute('aria-hidden', 'true');
 }
 
-function show (appElement) {
+export function show (appElement) {
   validateElement(appElement);
   (appElement || globalElement).removeAttribute('aria-hidden');
 }
 
-function toggle (shouldHide, appElement) {
+export function toggle (shouldHide, appElement) {
   if (shouldHide) {
     hide(appElement);
   } else { show(appElement); }
 }
 
-function resetForTesting () {
+export function resetForTesting () {
   globalElement = document.body;
 }
-
-exports.toggle = toggle;
-exports.setElement = setElement;
-exports.show = show;
-exports.hide = hide;
-exports.resetForTesting = resetForTesting;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,3 @@
-module.exports = require('./components/Modal');
+import Modal from './components/Modal';
 
+export default Modal;

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -11,7 +11,7 @@ import sinon from 'sinon';
 import expect from 'expect';
 import ReactDOM from 'react-dom';
 import Modal from '../lib/components/Modal';
-import ariaAppHider from '../lib/helpers/ariaAppHider';
+import * as ariaAppHider from '../lib/helpers/ariaAppHider';
 import { renderModal, unmountModal } from './helper';
 
 const Simulate = TestUtils.Simulate;


### PR DESCRIPTION
Changes proposed:
- Make use of es6 module

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
