### PR TITLE
[fixed]: undefined error in contentHasFocus method

### DIFF
--- a/dist/react-modal.js
+++ b/dist/react-modal.js
@@ -362,7 +362,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  focusContent: function focusContent() {
 	    // Don't steal focus from inner elements
 	    if (!this.contentHasFocus()) {
-	      this.refs.content.focus();
+	      this.refs.content && this.refs.content.focus();
 	    }
 	  },
 
@@ -427,7 +427,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 
 	  contentHasFocus: function contentHasFocus() {
-	    return document.activeElement === this.refs.content || this.refs.content.contains(document.activeElement);
+	    return document.activeElement === this.refs.content && this.refs.content.contains(document.activeElement);
 	  },
 
 	  buildClassName: function buildClassName(which, additional) {


### PR DESCRIPTION
Fixes #[issue number].
315
Changes proposed:
-  undefined check before invoking a property 
**original** : this.refs.content.focus()
**change needed**: this.refs.content && this.refs.content.focus()
- use of || in place of && 
**original**: : this.refs.content || this.refs.content.contains(document.activeElement
**change needed**: this.refs.content && this.refs.content.contains(document.activeElement
Upgrade Path (for changed or removed APIs):
Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
Note: npm test is broken in the latest codebase
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
