### PR TITLE
[fixed]: undefined error in contentHasFocus method

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -127,7 +127,7 @@ export default class ModalPortal extends Component {
   focusContent () {
     // Don't steal focus from inner elements
     if (!this.contentHasFocus()) {
-      this.content.focus();
+      this.content && this.content.focus();
     }
   }
 
@@ -193,7 +193,7 @@ export default class ModalPortal extends Component {
   }
 
   contentHasFocus () {
-    return document.activeElement === this.content || this.content.contains(document.activeElement);
+    return document.activeElement === this.content && this.content.contains(document.activeElement);
   }
 
   buildClassName (which, additional) {


### PR DESCRIPTION
Fixes #[issue number].
315
Changes proposed:
undefined check before invoking a property
**original**: this.content.focus()
**change needed**: this.content && this.content.focus()
use of || in place of &&
**original**:  this.content || this.content.contains(document.activeElement
**change needed**: this.content && this.content.contains(document.activeElement

Upgrade Path (for changed or removed APIs):
Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
Note: npm test is broken in the latest codebase(Issue#316)
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
