### PR TITLE
[changed] use object className and overlayClassName prop to override …

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ you can pass `className` and `overlayClassName` props to the Modal.  If you do
 this then none of the default styles will apply and you will have full control
 over styling via CSS.
 
+If you want to override default content and overlay classes you can pass object
+with three required properties: `base`, `afterOpen`, `beforeClose`.
+
+```jsx
+<Modal
+  ...
+  className={{
+    base: 'myClass',
+    afterOpen: 'myClass_after-open',
+    beforeClose: 'myClass_before-close'
+  }}
+  overlayClassName={{
+    base: 'myOverlayClass',
+    afterOpen: 'myOverlayClass_after-open',
+    beforeClose: 'myOverlayClass_before-close'
+  }}
+  ...
+>
+```
+
 You can also pass a `portalClassName` to change the wrapper's class (*ReactModalPortal*).
 This doesn't affect styling as no styles are applied to this element by default.
 
@@ -112,6 +132,7 @@ function getParent() {
 ### Body class
 When the modal is opened a `ReactModal__Body--open` class is added to the `body` tag.
 You can use this to remove scrolling on the the body while the modal is open.
+You can also pass a `bodyOpenClassName` to change the default class.
 
 ```CSS
 /* Remove scroll on the body when react-modal is open */

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -175,6 +175,32 @@ describe('Modal', () => {
     expect(modal.portal.overlay.className.indexOf('myOverlayClass')).toNotEqual(-1);
   });
 
+  it('overrides the default content classes when a custom object className is used', () => {
+    const modal = renderModal({
+      isOpen: true,
+      className: {
+        base: 'myClass',
+        afterOpen: 'myClass_after-open',
+        beforeClose: 'myClass_before-close'
+      }
+    });
+    expect(modal.portal.content.className).toEqual('myClass myClass_after-open');
+    unmountModal();
+  });
+
+  it('overrides the default overlay classes when a custom object overlayClassName is used', () => {
+    const modal = renderModal({
+      isOpen: true,
+      overlayClassName: {
+        base: 'myOverlayClass',
+        afterOpen: 'myOverlayClass_after-open',
+        beforeClose: 'myOverlayClass_before-close'
+      }
+    });
+    expect(modal.portal.overlay.className).toEqual('myOverlayClass myOverlayClass_after-open');
+    unmountModal();
+  });
+
   it('overrides the default styles when a custom classname is used', () => {
     const modal = renderModal({ ...getDefaultProps(), className: 'myClass' });
     expect(modal.portal.content.style.top).toEqual('');

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -21,6 +21,7 @@ export default class Modal extends Component {
       overlay: React.PropTypes.object
     }),
     portalClassName: React.PropTypes.string,
+    bodyOpenClassName: React.PropTypes.string,
     /**
      * A function that returns the appElement that will be aria-hidden
      * when the modal is open. The function should return a DOMElement or
@@ -41,6 +42,7 @@ export default class Modal extends Component {
   static defaultProps = {
     isOpen: false,
     portalClassName: 'ReactModalPortal',
+    bodyOpenClassName: 'ReactModal__Body--open',
     ariaHideApp: true,
     closeTimeoutMS: 0,
     shouldCloseOnOverlayClick: true,
@@ -125,14 +127,14 @@ export default class Modal extends Component {
     ReactDOM.unmountComponentAtNode(this.node);
     const parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);
-    elementClass(document.body).remove('ReactModal__Body--open');
+    elementClass(document.body).remove(this.props.bodyOpenClassName);
   }
 
   renderPortal (props) {
     if (props.isOpen) {
-      elementClass(document.body).add('ReactModal__Body--open');
+      elementClass(document.body).add(this.props.bodyOpenClassName);
     } else {
-      elementClass(document.body).remove('ReactModal__Body--open');
+      elementClass(document.body).remove(this.props.bodyOpenClassName);
     }
 
     if (props.ariaHideApp) {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -10,16 +10,8 @@ import {
 
 // so that our CSS is statically analyzable
 const CLASS_NAMES = {
-  overlay: {
-    base: 'ReactModal__Overlay',
-    afterOpen: 'ReactModal__Overlay--after-open',
-    beforeClose: 'ReactModal__Overlay--before-close'
-  },
-  content: {
-    base: 'ReactModal__Content',
-    afterOpen: 'ReactModal__Content--after-open',
-    beforeClose: 'ReactModal__Content--before-close'
-  }
+  overlay: 'ReactModal__Overlay',
+  content: 'ReactModal__Content'
 };
 
 export default class ModalPortal extends Component {
@@ -29,8 +21,22 @@ export default class ModalPortal extends Component {
     closeTimeoutMS: PropTypes.number,
     shouldCloseOnOverlayClick: PropTypes.bool,
     onRequestClose: PropTypes.func,
-    className: PropTypes.string,
-    overlayClassName: PropTypes.string,
+    className: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        base: PropTypes.string.isRequired,
+        afterOpen: PropTypes.string.isRequired,
+        beforeClose: PropTypes.string.isRequired
+      })
+    ]),
+    overlayClassName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        base: PropTypes.string.isRequired,
+        afterOpen: PropTypes.string.isRequired,
+        beforeClose: PropTypes.string.isRequired
+      })
+    ]),
     defaultStyles: PropTypes.shape({
       content: PropTypes.object,
       overlay: PropTypes.object
@@ -191,12 +197,15 @@ export default class ModalPortal extends Component {
   }
 
   buildClassName (which, additional) {
-    let className = CLASS_NAMES[which].base;
-    if (this.state.afterOpen) { className += ` ${CLASS_NAMES[which].afterOpen}`; }
-    if (this.state.beforeClose) {
-      className += ` ${CLASS_NAMES[which].beforeClose}`;
-    }
-    return additional ? `${className} ${additional}` : className;
+    const classNames = (typeof additional === 'object') ? additional : {
+      base: CLASS_NAMES[which],
+      afterOpen: `${CLASS_NAMES[which]}--after-open`,
+      beforeClose: `${CLASS_NAMES[which]}--before-close`
+    };
+    let className = classNames.base;
+    if (this.state.afterOpen) { className += ` ${classNames.afterOpen}`; }
+    if (this.state.beforeClose) { className += ` ${classNames.beforeClose}`; }
+    return (typeof additional === 'string' && additional) ? `${className} ${additional}` : className;
   }
 
   render () {


### PR DESCRIPTION
Changes proposed:
- use object className and overlayClassName prop to override the default content and overlay classes;
- use bodyOpenClassName to override body class name when modal opened.

Upgrade Path (for changed or removed APIs):
For overriding default content and overlay classes you can pass object
with three required properties: `base`, `afterOpen`, `beforeClose`.
```jsx
<Modal
  ...
  className={{
    base: 'myClass',
    afterOpen: 'myClass_after-open',
    beforeClose: 'myClass_before-close'
  }}
  overlayClassName={{
    base: 'myOverlayClass',
    afterOpen: 'myOverlayClass_after-open',
    beforeClose: 'myOverlayClass_before-close'
  }}
  ...
>
```
Old behavior is saved, when passed a string. 

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
