### PR TITLE
[fixed] remove es6 style functions.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -100,7 +100,7 @@ var Modal = React.createClass({
     }
   },
 
-  removePortal () {
+  removePortal: function() {
     ReactDOM.unmountComponentAtNode(this.node);
     var parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -77,7 +77,7 @@ var ModalPortal = module.exports = React.createClass({
     focusManager.teardownScopedFocus();
   },
 
-  open () {
+  open: function () {
     if (this.state.afterOpen && this.state.beforeClose) {
       clearTimeout(this.closeTimer);
       this.setState({ beforeClose: false });


### PR DESCRIPTION
fixes #336 

Changes proposed:
rewrite removePortal as es5 function

Uglifyjs doesn't know anything about es6, so 1.7.0 breaks my build script with error
```
ERROR in index_586f597d6f9d7177eb8b.js from UglifyJs
SyntaxError: Unexpected token punc «(», expected punc «:» [./~/react-modal/lib/components/Modal.js:103,0]
```
Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
