### PR TITLE
[chore] added missing babel transformer plugin.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "envify": "^3.4.1",


### PR DESCRIPTION
Running `webpack --config webpack.config.js` fails due to missing babel's spread transformer.

```javascript
ERROR in ./examples/basic/app.js
Module build failed: SyntaxError: Unexpected token (16:20)

  14 |
  15 |   openModal: function() {
> 16 |     this.setState({ ...this.state, modalIsOpen: true });
     |                     ^
  17 |   },
  18 |
  19 |   closeModal: function() {
```

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
