### PR TITLE
[added] refresh portalClassName on componentWillUpdate

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -66,6 +66,12 @@ var Modal = React.createClass({
     this.renderPortal(this.props);
   },
 
+  componentWillUpdate: function(newProps) {
+    if(newProps.portalClassName !== this.props.portalClassName) {
+      this.node.className = newProps.portalClassName;
+    }
+  },
+
   componentWillReceiveProps: function(newProps) {
     var currentParent = getParentElement(this.props.parentSelector);
     var newParent = getParentElement(newProps.parentSelector);

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -451,4 +451,42 @@ describe('Modal', () => {
       done();
     }, closeTimeoutMS);
   });
+
+  it('verify that portalClassName is refreshed on component update', () => {
+    var node = document.createElement('div');
+    var modal = null;
+
+    var App = React.createClass({
+      getInitialState: function () {
+        return {testHasChanged: false}
+      },
+
+      componentDidMount: function() {
+        expect(modal.node.className).toEqual('myPortalClass');
+
+        this.setState({
+          testHasChanged: true
+        });
+      },
+
+      componentDidUpdate: function() {
+        expect(modal.node.className).toEqual('myPortalClass-modifier');
+      },
+
+      render: function() {
+        return (
+          <div>
+            <Modal
+              ref={(modalComponent) => {modal = modalComponent}}
+              isOpen={true}
+              portalClassName={this.state.testHasChanged === true ? 'myPortalClass-modifier' : 'myPortalClass'}>
+            </Modal>
+          </div>
+        );
+      }
+    });
+
+    Modal.setAppElement(node);
+    ReactDOM.render(<App />, node);
+  });
 });


### PR DESCRIPTION
Changes proposed:
- Allow to change portalClassName on component update

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
