### PR TITLE
Adds `onAfterClose`

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -25,6 +25,7 @@ export default class Modal extends Component {
     portalClassName: React.PropTypes.string,
     appElement: React.PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: React.PropTypes.func,
+    onAfterClose: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
     closeTimeoutMS: React.PropTypes.number,
     ariaHideApp: React.PropTypes.bool,

--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -30,6 +30,7 @@ export default class ModalPortal extends Component {
     closeTimeoutMS: PropTypes.number,
     shouldCloseOnOverlayClick: PropTypes.bool,
     onRequestClose: PropTypes.func,
+    onAfterClose: React.PropTypes.func,
     className: PropTypes.string,
     overlayClassName: PropTypes.string,
     defaultStyles: PropTypes.shape({
@@ -97,6 +98,9 @@ export default class ModalPortal extends Component {
   afterClose = () => {
     returnFocus();
     teardownScopedFocus();
+    if (this.props.onAfterClose) {
+      this.props.onAfterClose();
+    }
   }
 
   open () {


### PR DESCRIPTION
Fixes https://github.com/reactjs/react-modal/issues/214

Changes proposed:
Adds `onAfterClose` handler