### PR TITLE
Remove .bind(this) from removePortal call

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -94,7 +94,7 @@ var Modal = React.createClass({
         this.portal.closeWithTimeout();
       }
 
-      setTimeout(this.removePortal.bind(this), closesAt - now);
+      setTimeout(function() { this.removePortal(); }, closesAt - now);
     } else {
       this.removePortal();
     }


### PR DESCRIPTION
This fixes this warning from react in the console without breaking functionality:

```
Warning: bind(): You are binding a component method to the component. React does this for you automatically in a high-performance way, so you can safely remove this call. See Modal
```

Fixes #344.

This doesn't fix a bug or change the API, it should be basically a "silent" change.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
