### PR TITLE
[fixed] remove portal context in timeout

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -94,7 +94,8 @@ var Modal = React.createClass({
         this.portal.closeWithTimeout();
       }
 
-      setTimeout(function() { this.removePortal(); }, closesAt - now);
+      var that = this;
+      setTimeout(function() { that.removePortal(); }, closesAt - now);
     } else {
       this.removePortal();
     }


### PR DESCRIPTION
Fixes #344, fixes #348.

Changes proposed:
- Fixes the binding of the `removePortal` call in the `setTimeout` callback
by capturing a this reference in a variable in the closure scope.
Doesn't use `bind` which apparently causes warnings.

Upgrade Path (for changed or removed APIs):
n/a

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
