### PR TITLE
focus on content after non close

### DIFF
--- a/lib/components/ModalPortal.js
+++ b/lib/components/ModalPortal.js
@@ -161,7 +161,9 @@ export default class ModalPortal extends Component {
     }
     if (this.shouldClose && this.props.shouldCloseOnOverlayClick) {
       if (this.ownerHandlesClose()) {
-        this.requestClose(event);
+        if (this.requestClose(event) === false) {
+          this.focusContent();
+        }
       } else {
         this.focusContent();
       }
@@ -175,7 +177,7 @@ export default class ModalPortal extends Component {
 
   requestClose (event) {
     if (this.ownerHandlesClose()) {
-      this.props.onRequestClose(event);
+      return this.props.onRequestClose(event);
     }
   }
 


### PR DESCRIPTION
My modal has a `busy` state and when it's `busy` it cannot be allowed to close.
So if in `onRequestClose` `busy` is `false` it plays an animation and doesn't close and returns `false`.
The issue is that the focus is lost.
This commit fixes the lost focus bug.