### PR TITLE
[fix] keep references of modals.

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -3,6 +3,7 @@ var ReactDOM = require('react-dom');
 var ExecutionEnvironment = require('exenv');
 var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
+var refCount = require('../helpers/refCount');
 var elementClass = require('element-class');
 var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeIntoContainer;
 var Assign = require('lodash.assign');
@@ -61,12 +62,16 @@ var Modal = React.createClass({
     this.node = document.createElement('div');
     this.node.className = this.props.portalClassName;
 
+    if (this.props.isOpen) refCount.add(this);
+
     var parent = getParentElement(this.props.parentSelector);
     parent.appendChild(this.node);
     this.renderPortal(this.props);
   },
 
   componentWillReceiveProps: function(newProps) {
+    if (newProps.isOpen) refCount.add(this);
+    if (!newProps.isOpen) refCount.remove(this);
     var currentParent = getParentElement(this.props.parentSelector);
     var newParent = getParentElement(newProps.parentSelector);
 
@@ -79,6 +84,8 @@ var Modal = React.createClass({
   },
 
   componentWillUnmount: function() {
+    refCount.remove(this);
+
     if (this.props.ariaHideApp) {
       ariaAppHider.show(this.props.appElement);
     }
@@ -105,11 +112,13 @@ var Modal = React.createClass({
     ReactDOM.unmountComponentAtNode(this.node);
     var parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);
-    elementClass(document.body).remove('ReactModal__Body--open');
+    if (refCount.count() === 0) {
+      elementClass(document.body).remove('ReactModal__Body--open');
+    }
   },
 
   renderPortal: function(props) {
-    if (props.isOpen) {
+    if (props.isOpen || refCount.count() > 0) {
       elementClass(document.body).add('ReactModal__Body--open');
     } else {
       elementClass(document.body).remove('ReactModal__Body--open');

--- a/lib/helpers/refCount.js
+++ b/lib/helpers/refCount.js
@@ -1,0 +1,19 @@
+const modals = [];
+
+export function add (element) {
+  if (modals.indexOf(element) === -1) {
+    modals.push(element);
+  }
+}
+
+export function remove (element) {
+  const index = modals.indexOf(element);
+  if (index === -1) {
+    return;
+  }
+  modals.splice(index, 1);
+}
+
+export function count () {
+  return modals.length;
+}

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -98,11 +98,15 @@ describe('Modal', () => {
     });
   });
 
-  it('give back focus to previous element or modal.', function (done) {
-    var modal = renderModal({
+  it('give back focus to previous element or modal.', (done) => {
+    function cleanup () {
+      unmountModal();
+      done();
+    }
+    const modal = renderModal({
       isOpen: true,
-      onRequestClose: function () {
-	done();
+      onRequestClose () {
+	cleanup();
       }
     }, null);
 
@@ -213,6 +217,17 @@ describe('Modal', () => {
     const modal = renderModal({ isOpen: true });
     expect(modal.portal.refs.content.style.position).toEqual(newStyle);
     Modal.defaultStyles.content.position = previousStyle;
+  });
+
+  it('should remove class from body when no modals opened', () => {
+    const findReactModalOpenClass = () => document.body.className.indexOf('ReactModal__Body--open');
+    renderModal({ isOpen: true });
+    renderModal({ isOpen: true });
+    expect(findReactModalOpenClass() > -1).toBe(true);
+    unmountModal();
+    expect(findReactModalOpenClass() > -1).toBe(true);
+    unmountModal();
+    expect(findReactModalOpenClass() === -1).toBe(true);
   });
 
   it('adds class to body when open', function() {


### PR DESCRIPTION
Keep a reference of all modals in order to manage
when to add/remove classes and aria from elements
correctly.

This solution is based on @MarkMurphy's idea #308, but it uses a simple list
to work on IE (don't really support Set).

Fixes #218 #231 #308.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.