### PR TITLE
[added] bool shouldCloseOnEsc to prevent modal closing on 'esc' press.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,10 @@ import ReactModal from 'react-modal';
   */
   shouldCloseOnOverlayClick={true}
   /*
+    Boolean indicating if the 'esc' key should close the modal
+   */
+  shouldCloseOnEsc={true}
+  /*
     String indicating the role of the modal, allowing the 'dialog' role to be applied if desired.
   */
   role="dialog"

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -86,6 +86,7 @@ describe('Modal', () => {
     expect(props.ariaHideApp).toBe(true);
     expect(props.closeTimeoutMS).toBe(0);
     expect(props.shouldCloseOnOverlayClick).toBe(true);
+    expect(props.shouldCloseOnEsc).toBe(true);
     ReactDOM.unmountComponentAtNode(node);
   });
 
@@ -299,6 +300,26 @@ describe('Modal', () => {
     expect(event).toBeTruthy();
     expect(event.constructor).toBeTruthy();
     expect(event.key).toEqual('FakeKeyToTestLater');
+  });
+
+  it('should not close on Esc key event when flagged not to', () => {
+    const requestCloseCallback = sinon.spy();
+    const modal = renderModal({
+      ...getDefaultProps(),
+      shouldCloseOnOverlayClick: true,
+      shouldCloseOnEsc: false,
+      onRequestClose: requestCloseCallback
+    });
+    expect(modal.props.isOpen).toEqual(true);
+    expect(() => {
+      Simulate.keyDown(modal.portal.content, {
+        // The keyCode is all that matters, so this works
+        key: 'FakeKeyToTestLater',
+        keyCode: 27,
+        which: 27
+      });
+    }).toNotThrow();
+    expect(!requestCloseCallback.called).toBeTruthy();
   });
 
   describe('Show/Hide appElement', () => {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -32,6 +32,7 @@ export default class Modal extends Component {
     closeTimeoutMS: React.PropTypes.number,
     ariaHideApp: React.PropTypes.bool,
     shouldCloseOnOverlayClick: React.PropTypes.bool,
+    shouldCloseOnEsc: React.PropTypes.bool,
     parentSelector: React.PropTypes.func,
     role: React.PropTypes.string,
     contentLabel: React.PropTypes.string.isRequired
@@ -44,6 +45,7 @@ export default class Modal extends Component {
     ariaHideApp: true,
     closeTimeoutMS: 0,
     shouldCloseOnOverlayClick: true,
+    shouldCloseOnEsc: true,
     parentSelector () { return document.body; }
   };
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -28,6 +28,7 @@ export default class ModalPortal extends Component {
     onAfterOpen: PropTypes.func,
     closeTimeoutMS: PropTypes.number,
     shouldCloseOnOverlayClick: PropTypes.bool,
+    shouldCloseOnEsc: PropTypes.bool,
     onRequestClose: PropTypes.func,
     className: PropTypes.string,
     overlayClassName: PropTypes.string,
@@ -150,7 +151,9 @@ export default class ModalPortal extends Component {
     if (event.keyCode === 9 /* tab*/) scopeTab(this.content, event);
     if (event.keyCode === 27 /* esc*/) {
       event.preventDefault();
-      this.requestClose(event);
+      if (this.props.shouldCloseOnEsc) {
+        this.requestClose(event);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #[363].

Changes proposed:
- Add boolean shouldCloseOnEsc
- Add test for said bool

Upgrade Path (for changed or removed APIs):
N/A

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [X] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [X] Documentation (README.md) and examples have been updated as needed.
- [X] If this is a code change, a spec testing the functionality has been added.
- [X] If the commit message has [changed] or [removed], there is an upgrade path above.
