### PR TITLE
Update React & Remove deprecated prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "karma-webpack": "^1.8.1",
     "mocha": "3.2.0",
     "npm-run-all": "^3.1.2",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0",
     "rf-release": "0.4.0",
     "rimraf": "^2.5.4",
     "sinon": "next",
@@ -79,8 +79,8 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.5.0",
+    "react-dom": "^0.14.0 || ^15.5.0"
   },
   "tags": [
     "react",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   },
   "dependencies": {
     "element-class": "^0.2.0",
-    "exenv": "1.2.0"
+    "exenv": "1.2.0",
+    "prop-types": "^15.5.7"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "mocha": "3.2.0",
     "npm-run-all": "^3.1.2",
     "react": "^15.5.0",
-    "react-addons-test-utils": "^15.5.0",
     "react-dom": "^15.5.0",
     "rf-release": "0.4.0",
     "rimraf": "^2.5.4",

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -5,7 +5,7 @@
 /* eslint react/no-find-dom-node: "warn",
           react/no-render-return-value: "warn"
 */
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import React from 'react';
 import sinon from 'sinon';
 import expect from 'expect';
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom';
 import Modal from '../src/components/Modal';
 import { renderModal, unmountModal, emptyDOM } from './helper';
 
-const Simulate = TestUtils.Simulate;
+const Simulate = ReactTestUtils.Simulate;
 
 function getDefaultProps () {
   return {
@@ -397,7 +397,7 @@ describe('Modal', () => {
           shouldCloseOnOverlayClick: false
         });
         expect(modal.props.isOpen).toEqual(true);
-        const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         expect(overlay.length).toEqual(1);
         Simulate.click(overlay[0]); // click the overlay
         expect(!requestCloseCallback.called).toBeTruthy();
@@ -413,7 +413,7 @@ describe('Modal', () => {
           }
         });
         expect(modal.props.isOpen).toEqual(true);
-        const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         expect(overlay.length).toEqual(1);
         Simulate.click(overlay[0]); // click the overlay
         expect(requestCloseCallback.called).toBeTruthy();
@@ -427,8 +427,8 @@ describe('Modal', () => {
           onRequestClose: requestCloseCallback
         });
         expect(modal.props.isOpen).toEqual(true);
-        const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
-        const content = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
+        const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        const content = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
         expect(overlay.length).toEqual(1);
         expect(content.length).toEqual(1);
         Simulate.mouseDown(overlay[0]); // click the overlay
@@ -446,8 +446,8 @@ describe('Modal', () => {
           }
         });
         expect(modal.props.isOpen).toEqual(true);
-        const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
-        const content = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
+        const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        const content = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Content');
         expect(content.length).toEqual(1);
         expect(overlay.length).toEqual(1);
         Simulate.mouseDown(content[0]); // click the overlay
@@ -461,7 +461,7 @@ describe('Modal', () => {
           ...getDefaultProps(),
           shouldCloseOnOverlayClick: true
         });
-        const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+        const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
         window.addEventListener('click', () => { hasPropagated = true; });
         // Work around for running the spec in IE 11
         let mouseEvent = null;
@@ -484,7 +484,7 @@ describe('Modal', () => {
         onRequestClose: requestCloseCallback
       });
       expect(modal.props.isOpen).toEqual(true);
-      const overlay = TestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
+      const overlay = ReactTestUtils.scryRenderedDOMComponentsWithClass(modal.portal, 'ReactModal__Overlay');
       expect(overlay.length).toEqual(1);
       // click the overlay
       Simulate.click(overlay[0], {
@@ -510,8 +510,8 @@ describe('Modal', () => {
     modal.portal.closeWithTimeout();
     unmountModal();
 
-    const overlay = TestUtils.findRenderedDOMComponentWithClass(modal.portal, 'ReactModal__Overlay');
-    const content = TestUtils.findRenderedDOMComponentWithClass(modal.portal, 'ReactModal__Content');
+    const overlay = ReactTestUtils.findRenderedDOMComponentWithClass(modal.portal, 'ReactModal__Overlay');
+    const content = ReactTestUtils.findRenderedDOMComponentWithClass(modal.portal, 'ReactModal__Content');
 
     expect(/ReactModal__Overlay--before-close/.test(overlay.className)).toBe(true);
     expect(/ReactModal__Content--before-close/.test(content.className)).toBe(true);

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import elementClass from 'element-class';
 import ModalPortal from './ModalPortal';
 import * as ariaAppHider from '../helpers/ariaAppHider';
@@ -15,26 +16,26 @@ export default class Modal extends Component {
 
   /* eslint-disable react/no-unused-prop-types */
   static propTypes = {
-    isOpen: React.PropTypes.bool.isRequired,
-    style: React.PropTypes.shape({
-      content: React.PropTypes.object,
-      overlay: React.PropTypes.object
+    isOpen: PropTypes.bool.isRequired,
+    style: PropTypes.shape({
+      content: PropTypes.object,
+      overlay: PropTypes.object
     }),
-    portalClassName: React.PropTypes.string,
+    portalClassName: PropTypes.string,
     /**
      * A function that returns the appElement that will be aria-hidden
      * when the modal is open. The function should return a DOMElement or
      * an array of DOMElements.
      */
-    getAppElement: React.PropTypes.func.isRequired,
-    onAfterOpen: React.PropTypes.func,
-    onRequestClose: React.PropTypes.func,
-    closeTimeoutMS: React.PropTypes.number,
-    ariaHideApp: React.PropTypes.bool,
-    shouldCloseOnOverlayClick: React.PropTypes.bool,
-    parentSelector: React.PropTypes.func,
-    role: React.PropTypes.string,
-    contentLabel: React.PropTypes.string.isRequired
+    getAppElement: PropTypes.func.isRequired,
+    onAfterOpen: PropTypes.func,
+    onRequestClose: PropTypes.func,
+    closeTimeoutMS: PropTypes.number,
+    ariaHideApp: PropTypes.bool,
+    shouldCloseOnOverlayClick: PropTypes.bool,
+    parentSelector: PropTypes.func,
+    role: PropTypes.string,
+    contentLabel: PropTypes.string.isRequired
   };
   /* eslint-enable react/no-unused-prop-types */
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import scopeTab from '../helpers/scopeTab';
 import {
   returnFocus,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -4368,13 +4368,6 @@ rc@~1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-addons-test-utils@^15.5.0:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
 
 react-dom@^15.5.0:
   version "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -4274,7 +4274,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.7:
+prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.7"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.7.tgz#231c4f29cdd82e355011d4889386ca9059544dd1"
   dependencies:
@@ -4369,28 +4369,30 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.0.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
+react-addons-test-utils@^15.5.0:
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dom@^15.0.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.0:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react@^15.0.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.0:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-cmd-shim@~1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -4274,6 +4274,12 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.5.7:
+  version "15.5.7"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.7.tgz#231c4f29cdd82e355011d4889386ca9059544dd1"
+  dependencies:
+    fbjs "^0.8.9"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -4446,30 +4452,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.0, readable-stream@^2.1.0, readable-stream@~2.1.4, readable-stream@~2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.2.2:
+"readable-stream@1 || 2", readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
   dependencies:
@@ -4489,6 +4472,29 @@ readable-stream@~1.0.2:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@~2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@~2.1.4, readable-stream@~2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
+  dependencies:
+    buffer-shims "^1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
 
 readdir-scoped-modules@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### Intro
Hi there! I am not 100% on the approach but I guess it is a good start? Since having `prop-types` is now a requirement, I've set the react peerDependency to be above `15.5.0`. I think that we might have to remove support for v14 because of the `prop-types` upcoming breaking change (or I am just confused about it?). More info about the `prop-types` change can be found on the [react blog](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html). 

At the same time, I replaced the deprecated `react-addons-test-utils` dependency with `react-dom/test-utils` and all tests seem to pass(at least locally!).

Let me know your thoughts 😄 

Fixes #366.

Changes proposed:
- Update react to v15.5.0
- Replace `React.PropTypes` with `PropTypes` from the package `prop-types`
- Remove deprecated `react-addons-test-utils`- Use `react-dom/test-utils`

Upgrade Path (for changed or removed APIs): ✖️ 

Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
