### PR TITLE
Use callback style ref in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ class App extends React.Component {
 
   afterOpenModal() {
     // references are now sync'd and can be accessed.
-    this.refs.subtitle.style.color = '#f00';
+    this.subtitle.style.color = '#f00';
   }
 
   closeModal() {
@@ -195,7 +195,7 @@ class App extends React.Component {
           contentLabel="Example Modal"
         >
 
-          <h2 ref="subtitle">Hello</h2>
+          <h2 ref={subtitle => this.subtitle = subtitle}>Hello</h2>
           <button onClick={this.closeModal}>close</button>
           <div>I am a modal</div>
           <form>


### PR DESCRIPTION
### Changes proposed:

Use callback style ref in the example of README since string refs are considered legacy and may be removed in the future.

### Upgrade Path (for changed or removed APIs):

N/A

### Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
