### PR TITLE
[change] deprecate getParentElement in favor of findDOMNode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,24 +107,8 @@ The default styles above are available on `Modal.defaultStyles`. Changes to this
 object will apply to all instances of the modal.
 
 ### Appended to custom node
-You can choose an element for the modal to be appended to, rather than using
-body tag. To do this, provide a function to `parentSelector` prop that return
-the element to be used.
-
-```jsx
-
-function getParent() {
-  return document.querySelector('#root');
-}
-
-<Modal
-  ...
-  parentSelector={getParent}
-  ...
->
-  <p>Modal Content.</p>
-</Modal>
-```
+`parentSelector` is now deprecated. `<Modal />` can be appended on any place
+and it will correctly manage it's clean up.
 
 ### Body class
 When the modal is opened a `ReactModal__Body--open` class is added to the `body` tag.

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -6,16 +6,14 @@ var ModalPortal = React.createFactory(require('./ModalPortal'));
 var ariaAppHider = require('../helpers/ariaAppHider');
 var refCount = require('../helpers/refCount');
 var elementClass = require('element-class');
-var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeIntoContainer;
+var renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
+var findDOMNode = ReactDOM.findDOMNode;
 var Assign = require('lodash.assign');
-var createReactClass = require('create-react-class')
+var createReactClass = require('create-react-class');
 
 var SafeHTMLElement = ExecutionEnvironment.canUseDOM ? window.HTMLElement : {};
 var AppElement = ExecutionEnvironment.canUseDOM ? document.body : {appendChild: function() {}};
 
-function getParentElement(parentSelector) {
-  return parentSelector();
-}
 
 var Modal = createReactClass({
 
@@ -45,7 +43,6 @@ var Modal = createReactClass({
     closeTimeoutMS: PropTypes.number,
     ariaHideApp: PropTypes.bool,
     shouldCloseOnOverlayClick: PropTypes.bool,
-    parentSelector: PropTypes.func,
     role: PropTypes.string,
     contentLabel: PropTypes.string.isRequired
   },
@@ -57,37 +54,28 @@ var Modal = createReactClass({
       bodyOpenClassName: 'ReactModal__Body--open',
       ariaHideApp: true,
       closeTimeoutMS: 0,
-      shouldCloseOnOverlayClick: true,
-      parentSelector: function () { return document.body; }
+      shouldCloseOnOverlayClick: true
     };
   },
 
   componentDidMount: function() {
-    this.node = document.createElement('div');
-    this.node.className = this.props.portalClassName;
+    this.node = findDOMNode(this);
 
     if (this.props.isOpen) refCount.add(this);
 
-    var parent = getParentElement(this.props.parentSelector);
-    parent.appendChild(this.node);
     this.renderPortal(this.props);
   },
 
   componentWillReceiveProps: function(newProps) {
     if (newProps.isOpen) refCount.add(this);
     if (!newProps.isOpen) refCount.remove(this);
-    var currentParent = getParentElement(this.props.parentSelector);
-    var newParent = getParentElement(newProps.parentSelector);
-
-    if(newParent !== currentParent) {
-      currentParent.removeChild(this.node);
-      newParent.appendChild(this.node);
-    }
 
     this.renderPortal(newProps);
   },
 
   componentWillUnmount: function() {
+    if (!this.portal) return;
+
     refCount.remove(this);
 
     if (this.props.ariaHideApp) {
@@ -114,9 +102,7 @@ var Modal = createReactClass({
 
   removePortal: function() {
     ReactDOM.unmountComponentAtNode(this.node);
-    var parent = getParentElement(this.props.parentSelector);
-    parent.removeChild(this.node);
-
+    this.portal = null;
     if (refCount.count() === 0) {
       elementClass(document.body).remove(this.props.bodyOpenClassName);
     }
@@ -133,11 +119,17 @@ var Modal = createReactClass({
       ariaAppHider.toggle(props.isOpen, props.appElement);
     }
 
-    this.portal = renderSubtreeIntoContainer(this, ModalPortal(Assign({}, props, {defaultStyles: Modal.defaultStyles})), this.node);
+    this.portal = renderSubtreeIntoContainer(
+      this,
+      ModalPortal(Assign({}, props, { defaultStyles: Modal.defaultStyles })),
+      this.node
+    );
   },
 
   render: function () {
-    return React.DOM.noscript();
+    return (
+      <div className={this.props.portalClassName}></div>
+    );
   }
 });
 
@@ -164,6 +156,6 @@ Modal.defaultStyles = {
     outline                 : 'none',
     padding                 : '20px'
   }
-}
+};
 
-module.exports = Modal
+module.exports = Modal;

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import sinon from 'sinon';
 import expect from 'expect';
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import Modal from '../lib/components/Modal';
@@ -60,26 +60,21 @@ describe('State', () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  it('renders into the body, not in context', () => {
+  it('renders in context, never in document.body', function() {
     var node = document.createElement('div');
     var App = React.createClass({
       render() {
-        return (
-          <div>
-            <Modal isOpen={true}>
-              <span>hello</span>
-            </Modal>
-          </div>
-        );
+	return (
+	  <Modal isOpen={true}>
+	    hello
+	  </Modal>
+	);
       }
     });
     Modal.setAppElement(node);
     ReactDOM.render(<App />, node);
-    expect(
-      document.body.querySelector('.ReactModalPortal').parentNode
-    ).toEqual(
-      document.body
-    );
+    var modalParent = node.querySelector('.ReactModalPortal').parentNode;
+    expect(modalParent).toEqual(node);
     ReactDOM.unmountComponentAtNode(node);
   });
 
@@ -307,5 +302,38 @@ describe('State', () => {
       checkDOM(0);
       done();
     }, closeTimeoutMS);
+  });
+
+  it('shouldn\'t throw if forcibly unmounted during mounting', () => {
+    /* eslint-disable camelcase, react/prop-types */
+    class Wrapper extends Component {
+      constructor (props) {
+        super(props);
+        this.state = { error: false };
+      }
+      unstable_handleError () {
+        this.setState({ error: true });
+      }
+      render () {
+        return this.state.error ? null : <div>{ this.props.children }</div>;
+      }
+    }
+    /* eslint-enable camelcase, react/prop-types */
+
+    const Throw = () => { throw new Error('reason'); };
+    const TestCase = () => (
+      <Wrapper>
+        <Modal />
+        <Throw />
+      </Wrapper>
+    );
+
+    const currentDiv = document.createElement('div');
+    document.body.appendChild(currentDiv);
+
+    const mount = () => ReactDOM.render(<TestCase />, currentDiv);
+    expect(mount).toNotThrow();
+
+    document.body.removeChild(currentDiv);
   });
 });


### PR DESCRIPTION
`findDOMNode` is available since React v0.14 and it's the minimum
version for `react-modal`.

To keep things simple, each Modal can be placed on any level
of the react's tree and it will do a proper clean up when it's
time to unmount the component. Also, it make things simple enough
to deal with overlapped modal.

Changes proposed:
- Use a `div` provided by the instance of <Modal /> to setup things.
- Each `<Modal />` can perform its own clean up.

Upgrade Path (for changed or removed APIs):
- Remove `getParentElement`.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
