### PR TITLE
fix react proptypes warning

### DIFF
--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -38,7 +38,7 @@ var Modal = createReactClass({
       overlay: PropTypes.object
     }),
     portalClassName: PropTypes.string,
-    bodyOpenClassName: React.PropTypes.string,
+    bodyOpenClassName: PropTypes.string,
     appElement: PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: PropTypes.func,
     onRequestClose: PropTypes.func,


### PR DESCRIPTION
Related to #366.

Changes proposed:
- Rename the missing PropType, to stop this warning :

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
