### PR TITLE
[chore] upgrade React devDeps to 15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
     "karma-webpack": "^1.8.1",
     "mocha": "3.2.0",
     "npm-run-all": "^3.1.2",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "rf-release": "0.4.0",
     "sinon": "next",
     "uglify-js": "2.4.24",
@@ -64,7 +63,7 @@
   "dependencies": {
     "element-class": "^0.2.0",
     "exenv": "1.2.0",
-    "prop-types": "^15.5.7",
+    "prop-types": "^15.5.10",
     "react-dom-factories": "^1.0.0"
   },
   "peerDependencies": {

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Modal from '../src/components/Modal';
 import {
   moverlay, mcontent,

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -2,7 +2,7 @@
 import expect from 'expect';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Modal from '../src/components/Modal';
 import * as ariaAppHider from '../src/helpers/ariaAppHider';
 import {

--- a/specs/Modal.style.spec.js
+++ b/specs/Modal.style.spec.js
@@ -2,7 +2,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import Modal from '../src/components/Modal';
 import * as ariaAppHider from '../src/helpers/ariaAppHider';
 import {

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Modal from '../src/components/Modal';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 const divStack = [];
 


### PR DESCRIPTION
Fixes #[issue number].

Changes proposed:
- Upgrade React to the latest version
- Remove the deprecated `react-addons-test-utils` in favor of accessing from `react-dom/test-utils`
-

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
