### PR TITLE
[fixed] incorrect focusAfterRender on componentDidUpdate.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -91,6 +91,14 @@ export default class ModalPortal extends Component {
     this.focusAfterRender = focus;
   }
 
+  setOverlayRef = (overlay) => {
+    this.overlay = overlay;
+  }
+
+  setContentRef = (content) => {
+    this.content = content;
+  }
+
   afterClose = () => {
     focusManager.returnFocus();
     focusManager.teardownScopedFocus();
@@ -209,12 +217,12 @@ export default class ModalPortal extends Component {
 
     return this.shouldBeClosed() ? <div /> : (
       <div
-        ref={overlay => { this.overlay = overlay; }}
+        ref={this.setOverlayRef}
         className={this.buildClassName('overlay', overlayClassName)}
         style={{ ...overlayStyles, ...this.props.style.overlay }}
         onClick={this.handleOverlayOnClick}>
         <div
-          ref={content => { this.content = content; }}
+          ref={this.setContentRef}
           style={{ ...contentStyles, ...this.props.style.content }}
           className={this.buildClassName('content', className)}
           tabIndex="-1"

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -130,7 +130,8 @@ export default class ModalPortal extends Component {
   }
 
   // Don't steal focus from inner elements
-  focusContent = () => (!this.contentHasFocus()) && this.content.focus();
+  focusContent = () => 
+    (this.content && !this.contentHasFocus()) && this.content.focus();
 
   closeWithTimeout = () => {
     const closesAt = Date.now() + this.props.closeTimeoutMS;

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -130,7 +130,7 @@ export default class ModalPortal extends Component {
   }
 
   // Don't steal focus from inner elements
-  focusContent = () => 
+  focusContent = () =>
     (this.content && !this.contentHasFocus()) && this.content.focus();
 
   closeWithTimeout = () => {


### PR DESCRIPTION
Maybe fixes #315.

Issue #315 seems to be a problem with inconsistent state when using react-modal with `redux` [1] (all errors seems to be reported by developer using redux).

It's not a proper fix since this behaviour was not reproduced, but it should be safe.

[1] - maybe a redux and/or component state async update. (?)

Changes proposed:
- don't try to focus if `this.content` is not available.
- Uses bound ref functions instead of arrow functions, as suggested by https://facebook.github.io/react/docs/refs-and-the-dom.html#caveats

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.