### PR TITLE
[fixed] Eliminate unnecessary renders when modal is closed

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -108,8 +108,12 @@ export default class Modal extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    if (newProps.isOpen) refCount.add(this);
-    if (!newProps.isOpen) refCount.remove(this);
+    const { isOpen } = newProps;
+    // Stop unnecessary renders if modal is remaining closed
+    if (!this.props.isOpen && !isOpen) return;
+
+    if (isOpen) refCount.add(this);
+    if (!isOpen) refCount.remove(this);
     const currentParent = getParentElement(this.props.parentSelector);
     const newParent = getParentElement(newProps.parentSelector);
 


### PR DESCRIPTION
Fixes #[issue number].

Changes proposed:
- Early return if the modal is closed and will remain closed. This prevents us from doing additional DOM check and running `renderPortal` again unnecessarily. This was my original intention with https://github.com/reactjs/react-modal/pull/328, but is greatly simplified with v2 code.

I wasn't exactly sure if we wanted another test as all current tests are passing and this one (https://github.com/reactjs/react-modal/blob/master/specs/Modal.spec.js#L233) covers the scenario of multiple modals rendering. 

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
