### PR TITLE
[fixed] Modal.removePortal not called when using closetimeoutMS

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -100,6 +100,27 @@ describe('State', () => {
     expect(document.querySelector('.ReactModalPortal')).toNotExist();
   });
 
+  it('removes the portal node after closeTimeoutMS', done => {
+    const closeTimeoutMS = 100;
+    renderModal({ isOpen: true, closeTimeoutMS }, 'hello');
+
+    function checkDOM(count) {
+      const portal = document.querySelectorAll('.ReactModalPortal');
+      expect(portal.length).toBe(count);
+    }
+
+    unmountModal();
+
+    // content is still mounted after modal is gone
+    checkDOM(1);
+
+    setTimeout(() => {
+      // content is unmounted after specified timeout
+      checkDOM(0);
+      done();
+    }, closeTimeoutMS);
+  });
+
   it('focuses the modal content', () => {
     const modal = renderModal({ isOpen: true }, null);
     expect(document.activeElement).toBe(mcontent(modal));

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -140,7 +140,7 @@ export default class Modal extends Component {
         this.portal.closeWithTimeout();
       }
 
-      setTimeout(() => this.removePortal, closesAt - now);
+      setTimeout(this.removePortal, closesAt - now);
     } else {
       this.removePortal();
     }


### PR DESCRIPTION
Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
