### PR TITLE
[chore] Change 'a11y' to 'accessibility' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install the stable version you can use [npm](https://npmjs.org/) or [yarn](ht
 The Modal object has two required props:
 
 - `isOpen` to render its children.
-- `contentLabel` to improve a11y, since `v1.6.0`.
+- `contentLabel` to improve accessibility, since `v1.6.0`.
 
 Example:
 


### PR DESCRIPTION
Changes proposed:
- Change 'a11y' to 'accessibility'. This shorthand is not obvious (I had to Google it), and unnecessary (there's no character limit).

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
