### PR TITLE
[added] Support using multiple document.body classes

### DIFF
--- a/docs/styles/classes.md
+++ b/docs/styles/classes.md
@@ -1,10 +1,22 @@
 ### CSS Classes
 
-Sometimes it may be preferable to use CSS classes rather than inline styles.  You can use the `className` and `overlayClassName` props to specify a given CSS class for each of those.
-You can override the default class that is added to `document.body` when the modal is open by defining a property `bodyOpenClassName`.
+Sometimes it may be preferable to use CSS classes rather than inline styles.
 
-It's required that `bodyOpenClassName` must be `constant string`, otherwise we would end up with a complex system to manage which class name
-should appear or be removed from `document.body` from which modal (if using multiple modals simultaneously).
+You can use the `className` and `overlayClassName` props to specify a given CSS
+class for each of those.
 
-Note: If you provide those props all default styles will not be applied, leaving all styles under control of the CSS class.
+You can override the default class that is added to `document.body` when the
+modal is open by defining a property `bodyOpenClassName`.
+
+It's required that `bodyOpenClassName` must be `constant string`, otherwise we
+would end up with a complex system to manage which class name should appear or
+be removed from `document.body` from which modal (if using multiple modals
+simultaneously).
+
+`bodyOpenClassName` can support adding multiple classes to `document.body` when
+the modal is open. Add as many class names as you desire, delineated by spaces.
+
+Note: If you provide those props all default styles will not be applied, leaving
+all styles under control of the CSS class.
+
 The `portalClassName` can also be used however there are no styles by default applied

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "webpack-dev-server": "1.11.0"
   },
   "dependencies": {
-    "element-class": "^0.2.0",
     "exenv": "1.2.0",
     "prop-types": "^15.5.10",
     "react-dom-factories": "^1.0.0"

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -271,6 +271,34 @@ describe('State', () => {
     expect(!isBodyWithReactModalOpenClass()).toBeTruthy();
   });
 
+  it('supports adding/removing multiple document.body classes', () => {
+    renderModal({
+      isOpen: true,
+      bodyOpenClassName: 'A B C'
+    });
+    expect(document.body.classList.contains('A', 'B', 'C')).toBeTruthy();
+    unmountModal();
+    expect(!document.body.classList.contains('A', 'B', 'C')).toBeTruthy();
+  });
+
+  it('does not remove shared classes if more than one modal is open', () => {
+    renderModal({
+      isOpen: true,
+      bodyOpenClassName: 'A'
+    });
+    renderModal({
+      isOpen: true,
+      bodyOpenClassName: 'A B'
+    });
+
+    expect(isBodyWithReactModalOpenClass('A B')).toBeTruthy();
+    unmountModal();
+    expect(!isBodyWithReactModalOpenClass('A B')).toBeTruthy();
+    expect(isBodyWithReactModalOpenClass('A')).toBeTruthy();
+    unmountModal();
+    expect(!isBodyWithReactModalOpenClass('A')).toBeTruthy();
+  });
+
   it('should not add classes to document.body for unopened modals', () => {
     renderModal({ isOpen: true });
     expect(isBodyWithReactModalOpenClass()).toBeTruthy();

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -8,9 +8,17 @@ const divStack = [];
 /**
  * Polyfill for String.includes on some node versions.
  */
-if (!(String.prototype.hasOwnProperty('includes'))) {
-  String.prototype.includes = function(item) {
-    return this.length > 0 && this.split(" ").indexOf(item) !== -1;
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+
+    if (start + search.length > this.length) {
+      return false;
+    }
+
+    return this.indexOf(search, start) !== -1;
   };
 }
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { PropTypes } from 'prop-types';
-import elementClass from 'element-class';
 import * as focusManager from '../helpers/focusManager';
 import scopeTab from '../helpers/scopeTab';
 import * as ariaAppHider from '../helpers/ariaAppHider';
 import * as refCount from '../helpers/refCount';
+import * as bodyClassList from '../helpers/bodyClassList';
 import SafeHTMLElement from '../helpers/safeHTMLElement';
 
 // so that our CSS is statically analyzable
@@ -119,9 +119,8 @@ export default class ModalPortal extends Component {
 
   beforeOpen() {
     const { appElement, ariaHideApp, bodyOpenClassName } = this.props;
-    refCount.add(bodyOpenClassName);
     // Add body class
-    elementClass(document.body).add(bodyOpenClassName);
+    bodyClassList.add(bodyOpenClassName);
     // Add aria-hidden to appElement
     if (ariaHideApp) {
       ariaAppHider.hide(appElement);
@@ -130,11 +129,8 @@ export default class ModalPortal extends Component {
 
   beforeClose() {
     const { appElement, ariaHideApp, bodyOpenClassName } = this.props;
-    refCount.remove(bodyOpenClassName);
     // Remove class if no more modals are open
-    if (refCount.count(bodyOpenClassName) === 0) {
-      elementClass(document.body).remove(bodyOpenClassName);
-    }
+    bodyClassList.remove(bodyOpenClassName);
     // Reset aria-hidden attribute if all modals have been removed
     if (ariaHideApp && refCount.totalCount() < 1) {
       ariaAppHider.show(appElement);

--- a/src/helpers/bodyClassList.js
+++ b/src/helpers/bodyClassList.js
@@ -1,0 +1,20 @@
+import * as refCount from './refCount';
+
+export function add (bodyClass) {
+  // Increment class(es) on refCount tracker and add class(es) to body
+  bodyClass
+    .split(' ')
+    .map(refCount.add)
+    .forEach(className => document.body.classList.add(className));
+}
+
+export function remove (bodyClass) {
+  const classListMap = refCount.get();
+  // Decrement class(es) from the refCount tracker
+  // and remove unused class(es) from body
+  bodyClass
+    .split(' ')
+    .map(refCount.remove)
+    .filter(className => classListMap[className] === 0)
+    .forEach(className => document.body.classList.remove(className));
+}

--- a/src/helpers/refCount.js
+++ b/src/helpers/refCount.js
@@ -1,23 +1,26 @@
-const modals = {};
+const classListMap = {};
+
+export function get() {
+  return classListMap;
+}
 
 export function add(bodyClass) {
   // Set variable and default if none
-  if (!modals[bodyClass]) {
-    modals[bodyClass] = 0;
+  if (!classListMap[bodyClass]) {
+    classListMap[bodyClass] = 0;
   }
-  modals[bodyClass] += 1;
+  classListMap[bodyClass] += 1;
+  return bodyClass;
 }
 
 export function remove(bodyClass) {
-  if (modals[bodyClass]) {
-    modals[bodyClass] -= 1;
+  if (classListMap[bodyClass]) {
+    classListMap[bodyClass] -= 1;
   }
-}
-
-export function count(bodyClass) {
-  return modals[bodyClass];
+  return bodyClass;
 }
 
 export function totalCount() {
-  return Object.keys(modals).reduce((acc, curr) => acc + modals[curr], 0);
+  return Object.keys(classListMap)
+    .reduce((acc, curr) => acc + classListMap[curr], 0);
 }


### PR DESCRIPTION
Fixes #451.

### Changes proposed:
- update `bodyOpenClassName` prop to handle adding and removing multiple class names
- update String#includes [polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) to work properly
- remove unmaintained and obsolete `element-class` library
- add new helper for adding/removing classes from the body element
- update refCount helper to have a getter and chainable methods

### Use Case

I am using the [Tachyons](http://tachyons.io/) library for CSS styling in my app. If you have not worked with Tachyons before (it's wonderful), it is essentially a collection of atomic class names—i.e., class names that do only one thing (e.g. `.fixed { position: fixed; }`). Because of this, it is in the nature of Tachyons that multiple classes will be tacked on to a single element to achieve a desired style.

Recently, I ran into the issue outlined in #369. To solve the issue, I need to apply two CSS properties to the `document.body` element when the modal opens: `position: fixed` and `overflow: hidden`.

To do this with Tachyons, I need to have `bodyOpenClassName='fixed overflow-hidden'`.

However, this causes a bug in the current version of the `react-modal` library in which the classes are appended ad infinitum ([see here](https://codepen.io/indiesquidge/pen/VWxzGN)).

### Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
