### PR TITLE
[chore] Mention shouldCloseOnOverlayClick dependency

### DIFF
--- a/docs/examples/should_close_on_overlay_click.md
+++ b/docs/examples/should_close_on_overlay_click.md
@@ -2,4 +2,6 @@
 
 This example shows using `shouldCloseOnOverlayClick` set to `false` so that closing by clicking on the overlay doesn't work.
 
+`shouldCloseOnOverlayClick` requires `onRequestClose` in order to close the <Modal/> because `react-modal` does not store `isOpen` in its local state.
+
 [](codepen://claydiffrient/woLzwo)


### PR DESCRIPTION
Mention shouldCloseOnOverlayClick dependency on onRequestClose in order to function properly.

Changes proposed:
- add mention that `shouldCloseOnOverlayClick` depends on having the `onRequestClose ` prop in order to function properly when it's set to `true`

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
