### PR TITLE
[fixed] `Uncaught TypeError: Cannot read property 'state' of null` when unmounting

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -127,7 +127,7 @@ export default class Modal extends Component {
   }
 
   componentWillUnmount() {
-    if (!this.node) return;
+    if (!this.node || !this.portal) return;
 
     const state = this.portal.state;
     const now = Date.now();


### PR DESCRIPTION
Fixes the following issue (Using React 16):

```js
Uncaught TypeError: Cannot read property 'state' of null
    at Modal.componentWillUnmount (Modal.js:119)
    at callComponentWillUnmountWithTimerInDev (react-dom.development.js:10413)
    at HTMLUnknownElement.callCallback (react-dom.development.js:1209)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:1248)
    at invokeGuardedCallback (react-dom.development.js:1105)
    at safelyCallComponentWillUnmount (react-dom.development.js:10421)
    at commitUnmount (react-dom.development.js:10711)
    at commitNestedUnmounts (react-dom.development.js:10575)
    at unmountHostComponents (react-dom.development.js:10632)
    at commitDeletion (react-dom.development.js:10682)
```

Fixes #476.

Changes proposed:
- check existence of `this.portal` before trying to access it's `state` property

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.