### PR TITLE
[fixed] Remove required flag from contentLabel propType in Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ To install the stable version you can use [npm](https://npmjs.org/) or [yarn](ht
 
 ## Usage
 
-The Modal object has two required props:
+The Modal object has one required prop:
 
 - `isOpen` to render its children.
-- `contentLabel` to improve accessibility, since `v1.6.0`.
 
 Example:
 
@@ -47,6 +46,8 @@ Example:
   <p>Etc.</p>
 </Modal>
 ```
+
+> Use the prop `contentLabel` which adds `aria-label` to the modal if there is no label text visible on the screen, otherwise specify the element including the label text using `aria-labelledby`
 
 ### App Element
 

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -93,7 +93,7 @@ describe('State', () => {
     expect(contentAttribute(modal, 'role')).toEqual('dialog');
   });
 
-  it('set aria-label based on the contentLabel prop', () => {
+  it('sets aria-label based on the contentLabel prop', () => {
     const child = 'I am a child of Modal, and he has sent me here...';
     const modal = renderModal({
       isOpen: true,

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -55,7 +55,7 @@ export default class Modal extends Component {
     parentSelector: PropTypes.func,
     aria: PropTypes.object,
     role: PropTypes.string,
-    contentLabel: PropTypes.string.isRequired
+    contentLabel: PropTypes.string
   };
   /* eslint-enable react/no-unused-prop-types */
 


### PR DESCRIPTION
Fixes #479.

Changes proposed:
ARIA spec, "If the label text is visible on screen, authors SHOULD use aria-labelledby and SHOULD NOT use aria-label." 
Changing contentLabel propType to not be required; reference id for aria-labelledby will now be supported.

Upgrade Path (for changed or removed APIs):
Won't affect existing code.

Acceptance Checklist:
- [X] All commits have been squashed to one.
- [X] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [X] Documentation (README.md) and examples have been updated as needed.
- [X] If this is a code change, a spec testing the functionality has been added.
- [X] If the commit message has [changed] or [removed], there is an upgrade path above.
