### PR TITLE
Export ES6 default property in CommonJS and global object

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015", "stage-2", "react"]
+  "presets": ["es2015", "stage-2", "react"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",


### PR DESCRIPTION
In Babel 5, the ES6 default property was exported as both default
property under the CommonJS export (module.exports) and global object
(in UMD wrapper, on browser). With babel 6 this behaviour was changed
(https://github.com/babel/babel/issues/2212) and now using library
requires e.g.

require("react-modal").default instead of just require("react-modal")
ReactModal.default instead of ReactModal

This babel plugin restores the old behaviour.

Fixes https://github.com/reactjs/react-modal/issues/470