### PR TITLE
[fixed] Drag stop (mouseup) on Overlay closes Modal

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -65,6 +65,7 @@ export default class ModalPortal extends Component {
     };
 
     this.shouldClose = null;
+    this.moveFromContentToOverlay = null;
   }
 
   componentDidMount() {
@@ -216,6 +217,21 @@ export default class ModalPortal extends Component {
       }
     }
     this.shouldClose = null;
+    this.moveFromContentToOverlay = null;
+  }
+
+  handleOverlayOnMouseUp = () => {
+    if (this.moveFromContentToOverlay === null) {
+      this.shouldClose = false;
+    }
+  }
+
+  handleContentOnMouseUp = () => {
+    this.shouldClose = false;
+  }
+
+  handleOverlayOnMouseDown = () => {
+    this.moveFromContentToOverlay = false;
   }
 
   handleContentOnClick = () => {
@@ -224,6 +240,7 @@ export default class ModalPortal extends Component {
 
   handleContentOnMouseDown = () => {
     this.shouldClose = false;
+    this.moveFromContentToOverlay = false;
   }
 
   requestClose = event =>
@@ -271,7 +288,9 @@ export default class ModalPortal extends Component {
         ref={this.setOverlayRef}
         className={this.buildClassName('overlay', overlayClassName)}
         style={{ ...overlayStyles, ...this.props.style.overlay }}
-        onClick={this.handleOverlayOnClick}>
+        onClick={this.handleOverlayOnClick}
+        onMouseDown={this.handleOverlayOnMouseDown}
+        onMouseUp={this.handleOverlayOnMouseUp}>
         <div
           ref={this.setContentRef}
           style={{ ...contentStyles, ...this.props.style.content }}
@@ -279,6 +298,7 @@ export default class ModalPortal extends Component {
           tabIndex="-1"
           onKeyDown={this.handleKeyDown}
           onMouseDown={this.handleContentOnMouseDown}
+          onMouseUp={this.handleContentOnMouseUp}
           onClick={this.handleContentOnClick}
           role={this.props.role}
           aria-label={this.props.contentLabel}


### PR DESCRIPTION
Fixes #515.

Changes proposed:
- Fixed drag stop on overlay closes modal
- Added moveFromContentToOverlay variable to check whether or not users drag from content to overlay

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
