### PR TITLE
[chore] remove warning about injectCSS.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -26,16 +26,6 @@ export default class Modal extends Component {
     ariaAppHider.setElement(element);
   }
 
-  /* eslint-disable no-console */
-  static injectCSS() {
-    (process.env.NODE_ENV !== "production")
-      && console.warn(
-        'React-Modal: injectCSS has been deprecated ' +
-          'and no longer has any effect. It will be removed in a later version'
-      );
-  }
-  /* eslint-enable no-console */
-
   /* eslint-disable react/no-unused-prop-types */
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,


### PR DESCRIPTION
`injectCSS` was deprecated since version 0.5.0.
Time to finally remove it.

Changes proposed:
- Remove warning.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
