### PR TITLE
[fixed] Issue #526 Import PropTypes as default import.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import * as focusManager from '../helpers/focusManager';
 import scopeTab from '../helpers/scopeTab';
 import * as ariaAppHider from '../helpers/ariaAppHider';


### PR DESCRIPTION
Fixes #526 .

Changes proposed:
- Import `PropTypes` as default.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
