### PR TITLE
[chore] Use babel-preset-env instead of babel-preset-es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-  "presets": ["es2015", "stage-2", "react"],
+  "presets": [
+    "env",
+    "react",
+    "stage-2"
+  ],
   "plugins": [
     "add-module-exports"
   ]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-eslint": "^8.0.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "coveralls": "^2.13.1",


### PR DESCRIPTION
Changes proposed:

This branch substitutes the usage of `babel-preset-es2015` with `babel-preset-env` as per [this recommendation](http://babeljs.io/env). Also, babel-preset-es2015 throws this warning messaging when installing:
```➜  react-modal git:(b3701f6) yarn
...
warning babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
...
```

Acceptance Checklist:
- [DONE] All commits have been squashed to one.
- [DONE] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [N/A] Documentation (README.md) and examples have been updated as needed.
- [N/A] If this is a code change, a spec testing the functionality has been added.
- [N/A] If the commit message has [changed] or [removed], there is an upgrade path above.
