### PR TITLE
[fixed] Removes body classNames after the modal is closed.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -98,6 +98,8 @@ export default class ModalPortal extends Component {
   }
 
   componentWillUnmount() {
+    // Remove body class
+    bodyClassList.remove(this.props.bodyOpenClassName);
     this.beforeClose();
     clearTimeout(this.closeTimer);
   }
@@ -125,9 +127,7 @@ export default class ModalPortal extends Component {
   }
 
   beforeClose() {
-    const { appElement, ariaHideApp, bodyOpenClassName } = this.props;
-    // Remove class if no more modals are open
-    bodyClassList.remove(bodyOpenClassName);
+    const { appElement, ariaHideApp } = this.props;
     // Reset aria-hidden attribute if all modals have been removed
     if (ariaHideApp && refCount.totalCount() < 1) {
       ariaAppHider.show(appElement);
@@ -135,6 +135,8 @@ export default class ModalPortal extends Component {
   }
 
   afterClose = () => {
+    // Remove body class
+    bodyClassList.remove(this.props.bodyOpenClassName);
     focusManager.returnFocus();
     focusManager.teardownScopedFocus();
   };


### PR DESCRIPTION
Fixes #508.

Changes proposed:
- Remove body classNames only after the modal is closed.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ]  If this is a code change, a spec testing the functionality has been added.
- [ ]  If the commit message has [changed] or [removed], there is an upgrade path above.
