### PR TITLE
[chore] specifiy the object when overriding class names.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -31,8 +31,22 @@ export default class Modal extends Component {
     }),
     portalClassName: PropTypes.string,
     bodyOpenClassName: PropTypes.string,
-    className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    overlayClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    className: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        base: PropTypes.string.isRequired,
+        afterOpen: PropTypes.string.isRequired,
+        beforeClose: PropTypes.string.isRequired
+      })
+    ]),
+    overlayClassName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        base: PropTypes.string.isRequired,
+        afterOpen: PropTypes.string.isRequired,
+        beforeClose: PropTypes.string.isRequired
+      })
+    ]),
     appElement: PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: PropTypes.func,
     onRequestClose: PropTypes.func,


### PR DESCRIPTION
Check for a precise object when settings class names
(`className` and `overlayClassName`) as object.

Fixes #533.

Changes proposed:
- Define the shape of the object.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
