### PR TITLE
[Fixed issue #464]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,11 @@ import ReactModal from 'react-modal';
   */
   shouldCloseOnEsc={true}
   /*
+    Boolean indicating if the modal should restore focus to the element that
+    had focus prior to its display.
+  */
+  shouldReturnFocusAfterClose={true}  
+  /*
     String indicating the role of the modal, allowing the 'dialog' role to be applied if desired.
   */
   role="dialog"

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -139,7 +139,7 @@ export default () => {
     document.activeElement.should.be.eql(mcontent(modal));
   });
 
-  it("does not focus the modal content when shouldFocusAfterRender is false", () => {
+  it("does not focus modal content if shouldFocusAfterRender is false", () => {
     const modal = renderModal(
       { isOpen: true, shouldFocusAfterRender: false },
       null
@@ -317,7 +317,7 @@ export default () => {
     isBodyWithReactModalOpenClass("testBodyClass").should.not.be.ok();
   });
 
-  it("should not remove classes from document.body when rendering unopened modal", () => {
+  it("should not remove classes from document.body if modal is closed", () => {
     renderModal({ isOpen: true });
     isBodyWithReactModalOpenClass().should.be.ok();
     renderModal({ isOpen: false, bodyOpenClassName: "testBodyClass" });
@@ -340,7 +340,7 @@ export default () => {
     unmountModal();
   });
 
-  it("adding/removing aria-hidden without an appElement will try to fallback to document.body", () => {
+  it("uses document.body for aria-hidden if no appElement", () => {
     ariaAppHider.documentNotReadyOrSSRTesting();
     const node = document.createElement("div");
     ReactDOM.render(<Modal isOpen />, node);
@@ -349,7 +349,7 @@ export default () => {
     should(document.body.getAttribute("aria-hidden")).not.be.ok();
   });
 
-  it("raise an exception if appElement is a selector and no elements were found.", () => {
+  it("raises an exception if the appElement selector does not match", () => {
     should(() => ariaAppHider.setElement(".test")).throw();
   });
 

--- a/specs/Modal.style.spec.js
+++ b/specs/Modal.style.spec.js
@@ -11,7 +11,7 @@ export default () => {
     mcontent(modal).style.top.should.be.eql("");
   });
 
-  it("overrides the default styles when a custom overlayClassName is used", () => {
+  it("overrides the default styles when using custom overlayClassName", () => {
     const modal = renderModal({
       isOpen: true,
       overlayClassName: "myOverlayClass"

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -54,6 +54,7 @@ export default class Modal extends Component {
     ariaHideApp: PropTypes.bool,
     shouldFocusAfterRender: PropTypes.bool,
     shouldCloseOnOverlayClick: PropTypes.bool,
+    shouldReturnFocusAfterClose: PropTypes.bool,
     parentSelector: PropTypes.func,
     aria: PropTypes.object,
     role: PropTypes.string,
@@ -71,6 +72,7 @@ export default class Modal extends Component {
     shouldFocusAfterRender: true,
     shouldCloseOnEsc: true,
     shouldCloseOnOverlayClick: true,
+    shouldReturnFocusAfterClose: true,
     parentSelector() {
       return document.body;
     }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -52,7 +52,7 @@ export default class Modal extends Component {
     onRequestClose: PropTypes.func,
     closeTimeoutMS: PropTypes.number,
     ariaHideApp: PropTypes.bool,
-    shouldFocusAfter: PropTypes.bool,
+    shouldFocusAfterRender: PropTypes.bool,
     shouldCloseOnOverlayClick: PropTypes.bool,
     parentSelector: PropTypes.func,
     aria: PropTypes.object,


### PR DESCRIPTION
Fixes #464.

Changes proposed:
- Adds a new prop `shouldReturnFocusAfterClose` allowing explicit control over if a modal should restore focus to the element that had focus prior to its displayed.
- Does not try to restore focus if focus wasn't transferred to the modal in the first place (`shouldFocusAfterRender` was set to `false`)
- Fixes a typo in the `Modal` props so that `shouldFocusAfter` is now correctly `shouldFocusAfterRender`
- Fixes a number of line-length warnings

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
