### PR TITLE
[fixed] shouldFocusAfterRender and shouldReturnFocusAfterClose flags.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -139,22 +139,14 @@ export default class ModalPortal extends Component {
     // Remove body class
     bodyClassList.remove(this.props.bodyOpenClassName);
 
-    if (this.shouldReturnFocus()) {
-      focusManager.returnFocus();
-      focusManager.teardownScopedFocus();
+    if (this.props.shouldFocusAfterRender) {
+      if (this.props.shouldReturnFocusAfterClose) {
+        focusManager.returnFocus();
+        focusManager.teardownScopedFocus();
+      } else {
+        focusManager.popWithoutFocus();
+      }
     }
-  };
-
-  shouldReturnFocus = () => {
-    // Don't restore focus to the element that had focus prior to
-    // the modal's display if:
-    // 1. Focus was never shifted to the modal in the first place
-    //    (shouldFocusAfterRender = false)
-    // 2. Explicit direction to not restore focus
-    return (
-      this.props.shouldFocusAfterRender ||
-      this.props.shouldReturnFocusAfterClose
-    );
   };
 
   open = () => {
@@ -163,7 +155,7 @@ export default class ModalPortal extends Component {
       clearTimeout(this.closeTimer);
       this.setState({ beforeClose: false });
     } else {
-      if (this.shouldReturnFocus()) {
+      if (this.props.shouldFocusAfterRender) {
         focusManager.setupScopedFocus(this.node);
         focusManager.markForFocusLater();
       }

--- a/src/helpers/focusManager.js
+++ b/src/helpers/focusManager.js
@@ -52,6 +52,10 @@ export function returnFocus() {
 }
 /* eslint-enable no-console */
 
+export function popWithoutFocus() {
+  focusLaterElements.length > 0 && focusLaterElements.pop();
+}
+
 export function setupScopedFocus(element) {
   modalElement = element;
 


### PR DESCRIPTION
Both options should work independent.

If `shouldFocusAfterRender` and `shouldReturnFocusAfterClose` are `true`,
the default behavior, it should focus the modal when open and return
the focus to the previous element when close.

If `shouldFocusAfterRender` is `false` and `shouldReturnFocusAfterClose` is `true`
should be the same as both option `false` - noop.

If `shouldFocusAfterRender` is `true` and `shouldReturnFocusAfterClose` is `false`,
then we focus the modal when open and on close we just pop the previous active
element from the focus manager w/o focus.

Changes proposed:
- Both options should work independent.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
