### PR TITLE
Prevent focus from leaving modal by clicking on overlay.

### DIFF
--- a/examples/basic/simple_usage/index.js
+++ b/examples/basic/simple_usage/index.js
@@ -76,6 +76,7 @@ class SimpleUsage extends Component {
           closeTimeoutMS={150}
           contentLabel="modalB"
           isOpen={currentModal == MODAL_B}
+          shouldCloseOnOverlayClick={false}
           onAfterOpen={this.handleOnAfterOpenModal}
           onRequestClose={this.toggleModal(MODAL_B)}>
           <h1 id="heading" ref={h1 => this.heading = h1}>This is the modal 2!</h1>

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -242,7 +242,10 @@ export default class ModalPortal extends Component {
     this.shouldClose = false;
   };
 
-  handleOverlayOnMouseDown = () => {
+  handleOverlayOnMouseDown = event => {
+    if (!this.props.shouldCloseOnOverlayClick) {
+      event.preventDefault();
+    }
     this.moveFromContentToOverlay = false;
   };
 


### PR DESCRIPTION
Fixes #186.

If the user doesn't allow close when clicking on the
overlay, we need to stop the event so the focus won't leave the modal
(where the key handler is defined).

Changes proposed:
- Prevent the mouse event when `shouldCloseOnOverlayClick` when set to false.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.