### PR TITLE
[fixed] shouldCloseOnOverlayClick conflict with text inputs.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -243,7 +243,7 @@ export default class ModalPortal extends Component {
   };
 
   handleOverlayOnMouseDown = event => {
-    if (!this.props.shouldCloseOnOverlayClick) {
+    if (!this.props.shouldCloseOnOverlayClick && event.target == this.overlay) {
       event.preventDefault();
     }
     this.moveFromContentToOverlay = false;


### PR DESCRIPTION
Fixes #566.

Changes proposed:
- When `shouldCloseOnOverlayClick={false}` the `handleOverlayOnMouseDown(event)` 
  must only do a `event.preventDefault()` when the click is really on the overlay.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.