### PR TITLE
[fixed] ignore .babelrc when publishing to npm.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,6 @@ examples
 karma.conf.js
 script
 specs
+.babelrc
 .idea/
 src


### PR DESCRIPTION
Fixes #569.
Fixes #457.
Fixes #450.

Changes proposed:
- Ignore `.babelrc` when publishing to npm.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
