### PR TITLE
Check if focusLaterElements array is empty before popping

### DIFF
--- a/src/helpers/focusManager.js
+++ b/src/helpers/focusManager.js
@@ -37,8 +37,10 @@ export function markForFocusLater() {
 export function returnFocus() {
   let toFocus = null;
   try {
-    toFocus = focusLaterElements.pop();
-    toFocus.focus();
+    if (focusLaterElements.length !== 0) {
+      toFocus = focusLaterElements.pop();
+      toFocus.focus();
+    }
     return;
   } catch (e) {
     console.warn(


### PR DESCRIPTION
Fixes #577.

## Changes proposed

Without a check to see if the `focusLaterElements` array is empty, we end up calling `pop()` on an empty array—resulting in an undefined value—and inadvertently jump to the `catch` block when we attempt to call `focus()` on `undefined`.

This PR ensures that if there are no existing elements to return focus to once our modal is closed (this happens often in a testing env), we do not throw a TypeError by accident.

## Acceptance Checklist

- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
