### PR TITLE
[added] add class to html when modal is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,17 @@ function getParent() {
 </Modal>
 ```
 
-### Body class
+### Body and Html class
 
 When the modal is opened a `ReactModal__Body--open` class is added to the `body` tag.
-You can use this to remove scrolling on the body while the modal is open.
+and a `ReactModal__Html--open` class is added to the `html` tag.
+You can use these to remove scrolling on the body while the modal is open.
 
 ```CSS
 /* Remove scroll on the body when react-modal is open */
-.ReactModal__Body--open {
+.ReactModal__Body--open,
+.ReactModal__Html--open {
+{
     overflow: hidden;
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,11 @@ import ReactModal from 'react-modal';
   */
   bodyOpenClassName="ReactModal__Body--open"
   /*
+     String className to be applied to the document.html (must be a constant string).
+     See the `Styles` section for more details.
+  */
+  htmlOpenClassName="ReactModal__Html--open"
+  /*
     Boolean indicating if the appElement should be hidden
   */
   ariaHideApp={true}

--- a/docs/styles/classes.md
+++ b/docs/styles/classes.md
@@ -8,12 +8,15 @@ class for each of those.
 You can override the default class that is added to `document.body` when the
 modal is open by defining a property `bodyOpenClassName`.
 
-It's required that `bodyOpenClassName` must be `constant string`, otherwise we
+You can override the default class that is added to `html` when the
+modal is open by defining a property `htmlOpenClassName`.
+
+It's required that `bodyOpenClassName` and `htmlOpenClassName` must be `constant string`, otherwise we
 would end up with a complex system to manage which class name should appear or
-be removed from `document.body` from which modal (if using multiple modals
+be removed from `document.body` and `html` from which modal (if using multiple modals
 simultaneously).
 
-`bodyOpenClassName` can support adding multiple classes to `document.body` when
+`bodyOpenClassName` and `htmlOpenClassName` can support adding multiple classes to `document.body` and `html` when
 the modal is open. Add as many class names as you desire, delineated by spaces.
 
 Note: If you provide those props all default styles will not be applied, leaving

--- a/examples/basic/app.css
+++ b/examples/basic/app.css
@@ -29,3 +29,8 @@
   transform: scale(0.5) rotateX(30deg);
   transition: all 150ms ease-in;
 }
+
+.ReactModal__Body--open,
+.ReactModal__Html--open {
+  overflow: hidden;
+}

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -6,6 +6,7 @@ import Modal from "react-modal";
 import * as ariaAppHider from "react-modal/helpers/ariaAppHider";
 import {
   isBodyWithReactModalOpenClass,
+  isHtmlWithReactModalOpenClass,
   contentAttribute,
   mcontent,
   moverlay,
@@ -253,32 +254,49 @@ export default () => {
     (document.body.className.indexOf("custom-modal-open") > -1).should.be.ok();
   });
 
-  it("don't append class to document.body if modal is not open", () => {
+  it("supports overriding react modal open class in html.", () => {
+    renderModal({ isOpen: true, htmlOpenClassName: "custom-modal-open" });
+    (
+      document
+        .getElementsByTagName("html")[0]
+        .className.indexOf("custom-modal-open") > -1
+    ).should.be.ok();
+  });
+
+  // eslint-disable-next-line max-len
+  it("don't append class to document.body and html if modal is not open", () => {
     renderModal({ isOpen: false });
     isBodyWithReactModalOpenClass().should.not.be.ok();
+    isHtmlWithReactModalOpenClass().should.not.be.ok();
     unmountModal();
   });
 
-  it("append class to document.body if modal is open", () => {
+  it("append class to document.body and html if modal is open", () => {
     renderModal({ isOpen: true });
     isBodyWithReactModalOpenClass().should.be.ok();
+    isHtmlWithReactModalOpenClass().should.be.ok();
     unmountModal();
   });
 
-  it("removes class from document.body when unmounted without closing", () => {
+  // eslint-disable-next-line max-len
+  it("removes class from document.body and html when unmounted without closing", () => {
     renderModal({ isOpen: true });
     unmountModal();
     isBodyWithReactModalOpenClass().should.not.be.ok();
+    isHtmlWithReactModalOpenClass().should.not.be.ok();
   });
 
-  it("remove class from document.body when no modals opened", () => {
+  it("remove class from document.body and html when no modals opened", () => {
     renderModal({ isOpen: true });
     renderModal({ isOpen: true });
     isBodyWithReactModalOpenClass().should.be.ok();
+    isHtmlWithReactModalOpenClass().should.be.ok();
     unmountModal();
     isBodyWithReactModalOpenClass().should.be.ok();
+    isHtmlWithReactModalOpenClass().should.be.ok();
     unmountModal();
     isBodyWithReactModalOpenClass().should.not.be.ok();
+    isHtmlWithReactModalOpenClass().should.not.be.ok();
   });
 
   it("supports adding/removing multiple document.body classes", () => {
@@ -326,6 +344,59 @@ export default () => {
     renderModal({ isOpen: false });
     renderModal({ isOpen: false });
     isBodyWithReactModalOpenClass().should.be.ok();
+  });
+
+  it("supports adding/removing multiple html classes", () => {
+    renderModal({
+      isOpen: true,
+      htmlOpenClassName: "A B C"
+    });
+    document
+      .getElementsByTagName("html")[0]
+      .classList.contains("A", "B", "C")
+      .should.be.ok();
+    unmountModal();
+    document
+      .getElementsByTagName("html")[0]
+      .classList.contains("A", "B", "C")
+      .should.not.be.ok();
+  });
+
+  it("does not remove shared classes if more than one modal is open", () => {
+    renderModal({
+      isOpen: true,
+      htmlOpenClassName: "A"
+    });
+    renderModal({
+      isOpen: true,
+      htmlOpenClassName: "A B"
+    });
+
+    isHtmlWithReactModalOpenClass("A B").should.be.ok();
+    unmountModal();
+    isHtmlWithReactModalOpenClass("A B").should.not.be.ok();
+    isHtmlWithReactModalOpenClass("A").should.be.ok();
+    unmountModal();
+    isHtmlWithReactModalOpenClass("A").should.not.be.ok();
+  });
+
+  it("should not add classes to html for unopened modals", () => {
+    renderModal({ isOpen: true });
+    isHtmlWithReactModalOpenClass().should.be.ok();
+    renderModal({ isOpen: false, htmlOpenClassName: "testHtmlClass" });
+    isHtmlWithReactModalOpenClass("testHtmlClass").should.not.be.ok();
+  });
+
+  it("should not remove classes from html if modal is closed", () => {
+    renderModal({ isOpen: true });
+    isHtmlWithReactModalOpenClass().should.be.ok();
+    renderModal({ isOpen: false, htmlOpenClassName: "testHtmlClass" });
+    renderModal({ isOpen: false });
+    isHtmlWithReactModalOpenClass("testHtmlClass").should.not.be.ok();
+    isHtmlWithReactModalOpenClass().should.be.ok();
+    renderModal({ isOpen: false });
+    renderModal({ isOpen: false });
+    isHtmlWithReactModalOpenClass().should.be.ok();
   });
 
   it("additional aria attributes", () => {

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -1,6 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Modal, { bodyOpenClassName } from "../src/components/Modal";
+import Modal, {
+  bodyOpenClassName,
+  htmlOpenClassName
+} from "../src/components/Modal";
 import TestUtils from "react-dom/test-utils";
 
 const divStack = [];
@@ -29,6 +32,14 @@ if (!String.prototype.includes) {
  */
 export const isBodyWithReactModalOpenClass = (bodyClass = bodyOpenClassName) =>
   document.body.className.includes(bodyClass);
+
+/**
+ * Check if the html contains the react modal
+ * open class.
+ * @return {Boolean}
+ */
+export const isHtmlWithReactModalOpenClass = (htmlClass = htmlOpenClassName) =>
+  document.getElementsByTagName("html")[0].className.includes(htmlClass);
 
 /**
  * Returns a rendered dom element by class.

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -7,6 +7,7 @@ import SafeHTMLElement, { canUseDOM } from "../helpers/safeHTMLElement";
 
 export const portalClassName = "ReactModalPortal";
 export const bodyOpenClassName = "ReactModal__Body--open";
+export const htmlOpenClassName = "ReactModal__Html--open";
 
 const isReact16 = ReactDOM.createPortal !== undefined;
 const createPortal = isReact16
@@ -31,6 +32,7 @@ export default class Modal extends Component {
     }),
     portalClassName: PropTypes.string,
     bodyOpenClassName: PropTypes.string,
+    htmlOpenClassName: PropTypes.string,
     className: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({
@@ -67,6 +69,7 @@ export default class Modal extends Component {
     isOpen: false,
     portalClassName,
     bodyOpenClassName,
+    htmlOpenClassName,
     ariaHideApp: true,
     closeTimeoutMS: 0,
     shouldFocusAfterRender: true,

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -4,7 +4,7 @@ import * as focusManager from "../helpers/focusManager";
 import scopeTab from "../helpers/scopeTab";
 import * as ariaAppHider from "../helpers/ariaAppHider";
 import * as refCount from "../helpers/refCount";
-import * as bodyClassList from "../helpers/bodyClassList";
+import * as classList from "../helpers/classList";
 import SafeHTMLElement from "../helpers/safeHTMLElement";
 
 // so that our CSS is statically analyzable
@@ -37,6 +37,7 @@ export default class ModalPortal extends Component {
     className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     overlayClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     bodyOpenClassName: PropTypes.string,
+    htmlOpenClassName: PropTypes.string,
     ariaHideApp: PropTypes.bool,
     appElement: PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: PropTypes.func,
@@ -81,6 +82,13 @@ export default class ModalPortal extends Component {
             "This may cause unexpected behavior when multiple modals are open."
         );
       }
+      if (newProps.htmlOpenClassName !== this.props.htmlOpenClassName) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'React-Modal: "htmlOpenClassName" prop has been modified. ' +
+            "This may cause unexpected behavior when multiple modals are open."
+        );
+      }
     }
     // Focus only needs to be set once when the modal is being opened
     if (!this.props.isOpen && newProps.isOpen) {
@@ -116,9 +124,15 @@ export default class ModalPortal extends Component {
   };
 
   beforeOpen() {
-    const { appElement, ariaHideApp, bodyOpenClassName } = this.props;
-    // Add body class
-    bodyClassList.add(bodyOpenClassName);
+    const {
+      appElement,
+      ariaHideApp,
+      bodyOpenClassName,
+      htmlOpenClassName
+    } = this.props;
+    // Add body and html class
+    classList.add(document.body, bodyOpenClassName);
+    classList.add(document.getElementsByTagName("html")[0], htmlOpenClassName);
     // Add aria-hidden to appElement
     if (ariaHideApp) {
       ariaAppHider.hide(appElement);
@@ -128,8 +142,12 @@ export default class ModalPortal extends Component {
   afterClose = () => {
     const { appElement, ariaHideApp } = this.props;
 
-    // Remove body class
-    bodyClassList.remove(this.props.bodyOpenClassName);
+    // Remove body and html class
+    classList.remove(document.body, this.props.bodyOpenClassName);
+    classList.remove(
+      document.getElementsByTagName("html")[0],
+      this.props.htmlOpenClassName
+    );
 
     // Reset aria-hidden attribute if all modals have been removed
     if (ariaHideApp && refCount.totalCount() < 1) {

--- a/src/helpers/classList.js
+++ b/src/helpers/classList.js
@@ -1,20 +1,20 @@
 import * as refCount from "./refCount";
 
-export function add(bodyClass) {
+export function add(element, elementClass) {
   // Increment class(es) on refCount tracker and add class(es) to body
-  bodyClass
+  elementClass
     .split(" ")
     .map(refCount.add)
-    .forEach(className => document.body.classList.add(className));
+    .forEach(className => element.classList.add(className));
 }
 
-export function remove(bodyClass) {
+export function remove(element, elementClass) {
   const classListMap = refCount.get();
   // Decrement class(es) from the refCount tracker
   // and remove unused class(es) from body
-  bodyClass
+  elementClass
     .split(" ")
     .map(refCount.remove)
     .filter(className => classListMap[className] === 0)
-    .forEach(className => document.body.classList.remove(className));
+    .forEach(className => element.classList.remove(className));
 }

--- a/src/helpers/refCount.js
+++ b/src/helpers/refCount.js
@@ -4,20 +4,20 @@ export function get() {
   return classListMap;
 }
 
-export function add(bodyClass) {
+export function add(className) {
   // Set variable and default if none
-  if (!classListMap[bodyClass]) {
-    classListMap[bodyClass] = 0;
+  if (!classListMap[className]) {
+    classListMap[className] = 0;
   }
-  classListMap[bodyClass] += 1;
-  return bodyClass;
+  classListMap[className] += 1;
+  return className;
 }
 
-export function remove(bodyClass) {
-  if (classListMap[bodyClass]) {
-    classListMap[bodyClass] -= 1;
+export function remove(className) {
+  if (classListMap[className]) {
+    classListMap[className] -= 1;
   }
-  return bodyClass;
+  return className;
 }
 
 export function totalCount() {


### PR DESCRIPTION
- Fixes #60  on browsers where `overflow:hidden` on `body` is not enough
- Fixes #251 on browsers where `overflow:hidden` on `body` is not enough

Changes proposed:
- add class to `html` when modal is open

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

This addition involves renaming some helpers from `bodyClass` to more generic terms.

  