### PR TITLE
[fixed] when ModalPortal is clicked, shouldClose is true if shouldClo…

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -232,6 +232,9 @@ export default class ModalPortal extends Component {
     if (this.moveFromContentToOverlay === null) {
       this.shouldClose = false;
     }
+    if (this.props.shouldCloseOnOverlayClick) {
+      this.shouldClose = true;
+    }
   };
 
   handleContentOnMouseUp = () => {


### PR DESCRIPTION
- Fixes #590.

Changes proposed:
- To close it at once on Linux although I opened a modal using mouse right click.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.

  