### PR TITLE
[fixed] Tab focus escapes modal on shift + tab after opening

### DIFF
--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -44,6 +44,21 @@ export default () => {
     document.activeElement.should.be.eql(content);
   });
 
+  it("Traps tab in the modal one shift + tab", () => {
+    const topButton = <button>top</button>;
+    const bottomButton = <button>bottom</button>;
+    const modalContent = (
+      <div>
+        {topButton}
+        {bottomButton}
+      </div>
+    );
+    const modal = renderModal({ isOpen: true }, modalContent);
+    const content = mcontent(modal);
+    tabKeyDown(content, { shiftKey: true });
+    document.activeElement.textContent.should.be.eql("bottom");
+  });
+
   describe("shouldCloseOnEsc", () => {
     context("when true", () => {
       it("should close on Esc key event", () => {

--- a/src/helpers/scopeTab.js
+++ b/src/helpers/scopeTab.js
@@ -13,9 +13,11 @@ export default function scopeTab(node, event) {
   const head = tabbable[0];
   const tail = tabbable[tabbable.length - 1];
 
-  // proceed with default browser behavior
+  // proceed with default browser behavior on tab.
+  // Focus on last element on shift + tab.
   if (node === document.activeElement) {
-    return;
+    if (!shiftKey) return;
+    target = tail;
   }
 
   var target;


### PR DESCRIPTION
Fixes #607.

Changes proposed:

Focusing the last tabbable element on `shift` + `tab` if the tab focus is on the modal content by checking if the shift key is active in `scopeTab` when tabbing off the modal content. Because the modal content has `tabindex="-1"`, this _should_ only happen after focus is programmatically given to the modal content on open.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
