### PR TITLE
[chore] add to docs the default value of the html class option.

### DIFF
--- a/docs/styles/classes.md
+++ b/docs/styles/classes.md
@@ -63,7 +63,7 @@ non-default `bodyOpenClassName`), you could use the following CSS:
 
 You can define a class to be added to the html tag, using the `htmlOpenClassName`
 attribute, which can be helpeful to stop the page to scroll to the top when open
-a modal.
+a modal. The default value is `null`.
 
 This attribute follows the same rules as `bodyOpenClassName`, it must be a *constant string*;
 


### PR DESCRIPTION
There is only one place that mention about the default value of the `htmlOpenClassName`.

Fixing by adding it to the [docs/styles/classes.md](https://github.com/reactjs/react-modal/blob/master/docs/styles/classes.md) page.

Changes proposed:
- None

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.