### PR TITLE
[fixed] portal node will be reparented if necessary on props change

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -123,8 +123,6 @@ export default class Modal extends Component {
   componentWillReceiveProps(newProps) {
     if (!canUseDOM) return;
     const { isOpen } = newProps;
-    // Stop unnecessary renders if modal is remaining closed
-    if (!this.props.isOpen && !isOpen) return;
 
     const currentParent = getParentElement(this.props.parentSelector);
     const newParent = getParentElement(newProps.parentSelector);
@@ -133,6 +131,9 @@ export default class Modal extends Component {
       currentParent.removeChild(this.node);
       newParent.appendChild(this.node);
     }
+
+    // Stop unnecessary renders if modal is remaining closed
+    if (!this.props.isOpen && !isOpen) return;
 
     !isReact16 && this.renderPortal(newProps);
   }
@@ -170,7 +171,7 @@ export default class Modal extends Component {
     const parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);
   };
-
+  
   portalRef = ref => {
     this.portal = ref;
   };

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -171,7 +171,7 @@ export default class Modal extends Component {
     const parent = getParentElement(this.props.parentSelector);
     parent.removeChild(this.node);
   };
-  
+
   portalRef = ref => {
     this.portal = ref;
   };


### PR DESCRIPTION
Fixes #626 .

Changes proposed:
- Stop bailing before node reparenting in componentWillReceiveProps 

Upgrade Path (for changed or removed APIs): non-breaking-change


Acceptance Checklist:
- [ ] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
