### PR TITLE
[fixed] mouse up event on overlay triggered the closing of the modal

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -266,16 +266,6 @@ export default class ModalPortal extends Component {
       }
     }
     this.shouldClose = null;
-    this.moveFromContentToOverlay = null;
-  };
-
-  handleOverlayOnMouseUp = () => {
-    if (this.moveFromContentToOverlay === null) {
-      this.shouldClose = false;
-    }
-    if (this.props.shouldCloseOnOverlayClick) {
-      this.shouldClose = true;
-    }
   };
 
   handleContentOnMouseUp = () => {
@@ -286,7 +276,6 @@ export default class ModalPortal extends Component {
     if (!this.props.shouldCloseOnOverlayClick && event.target == this.overlay) {
       event.preventDefault();
     }
-    this.moveFromContentToOverlay = false;
   };
 
   handleContentOnClick = () => {
@@ -295,7 +284,6 @@ export default class ModalPortal extends Component {
 
   handleContentOnMouseDown = () => {
     this.shouldClose = false;
-    this.moveFromContentToOverlay = false;
   };
 
   requestClose = event =>
@@ -348,7 +336,6 @@ export default class ModalPortal extends Component {
         style={{ ...overlayStyles, ...this.props.style.overlay }}
         onClick={this.handleOverlayOnClick}
         onMouseDown={this.handleOverlayOnMouseDown}
-        onMouseUp={this.handleOverlayOnMouseUp}
         aria-modal="true"
       >
         <div


### PR DESCRIPTION
Fixes #633

The code that should prevent the closing the modal by moving from content to the overlay was actually closing the modal `onMouseUp. By removing that part the modal only closes on an click  outside the boundaries of the content.

Changes proposed:
- Removing the onMouseUp event on the overlay element
- Removing the moveFromContentToOverlay variable from ModalPortal

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
