### PR TITLE
removed un-safe lifecycle methods componentWillMount and componentWillUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prettier": "^1.7.4",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-lifecycles-compat": "^1.1.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "should": "^13.1.0",


### PR DESCRIPTION
Implemented getDerivedStateFromProps and getSnapshotBeforeUpdate lifecycle methods using react-lifecycles-compat polyfill.

Fixes #637 .

Changes proposed (need some guidance with these):
- I removed the use of `prevProps` entirely according to the suggestion [here](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html). Which leaves us the option to use State. So I had to assign `defaultProps` to initial state and start mutating from there on.
- I implemented the `getSnapshotBeforeUpdate` method which replaces(sort of) the componentWillUpdate hook, but I'm not sure if I'm updating the `this.node` correctly?
- Now that we don't have access to `prevProps`, I'm having a trouble implementing `getParentElement` function. Since the way react works, is pass the `prevState` to `getDerivedStateFromProps` via recursion(kind of) in which case the getParentElement call gets recursed throwing an error. I need a suggestion for solid implementation of this without the use of `prevProps` IMHO. Functionality wise the current implementation is working but fails the `propTypes`(obviously).


Acceptance Checklist:
- [x] All commits have been squashed to one.
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
