### PR TITLE
[chore] update the pull request template...

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Fixes #[issue number].
 
 Changes proposed:
--
+
 -
 -
 
@@ -9,7 +9,6 @@ Upgrade Path (for changed or removed APIs):
 
 
 Acceptance Checklist:
-- [ ] All commits have been squashed to one.
 - [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
 - [ ] Documentation (README.md) and examples have been updated as needed.
 - [ ] If this is a code change, a spec testing the functionality has been added.


### PR DESCRIPTION
Users are not required to squash their commits. Github
now provides an option to do that on the gui.

Changes proposed:

- Remove squash requirement when writing a PR. It can be done when merging.

Upgrade Path (for changed or removed APIs):
- None

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
