### PR TITLE
Added default prop for defaultStyles property

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -22,7 +22,8 @@ export default class ModalPortal extends Component {
     style: {
       overlay: {},
       content: {}
-    }
+    },
+    defaultStyles: {}
   };
 
   static propTypes = {


### PR DESCRIPTION
Fixes #[issue number].
No issue

Changes proposed:
I added defaultProp for `"defaultStyles"` prop because in render method when classname dosn't provided we are trying to access `"defaultStyles.content"` and `"defaultStyles.overlay"` properties which will cause `"TypeError"`

Upgrade Path (for changed or removed APIs):
None

