### PR TITLE
[added] `testId` prop for use as a test hook

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -53,7 +53,8 @@ export default class ModalPortal extends Component {
     children: PropTypes.node,
     shouldCloseOnEsc: PropTypes.bool,
     overlayRef: PropTypes.func,
-    contentRef: PropTypes.func
+    contentRef: PropTypes.func,
+    testId: PropTypes.string
   };
 
   constructor(props) {
@@ -345,6 +346,7 @@ export default class ModalPortal extends Component {
           role={this.props.role}
           aria-label={this.props.contentLabel}
           {...this.ariaAttributes(this.props.aria || {})}
+          data-testid={this.props.testId}
         >
           {this.props.children}
         </div>


### PR DESCRIPTION
Relevant issue: #605.

Rather than allow arbitrary `data-*` attributes, I thought a simpler solution would be to have a specific prop for `testId`. Draft-js has a similar approach.

Changes proposed:

- `testId` prop for use as a test hook
- output to DOM as `data-testid` (which seems to sort of be react community standard). 

Upgrade Path (for changed or removed APIs):

N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
