### PR TITLE
Add module field to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.2",
   "description": "Accessible modal dialog component for React.JS",
   "main": "./lib/index.js",
+  "module": "./src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/reactjs/react-modal.git"


### PR DESCRIPTION
Changes proposed:

- For adapt legacy browser (e.g IE11), add `module` field to build by their own babel config with webpack, or other bundle tools.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
