### PR TITLE
[fixed]  Add missing test and a safety check for ssr

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -84,6 +84,28 @@ export default () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  it("allows setting appElement of type string", () => {
+    const node = document.createElement("div");
+    class App extends Component {
+      render() {
+        return (
+          <div>
+            <Modal isOpen>
+              <span>hello</span>
+            </Modal>
+          </div>
+        );
+      }
+    }
+    const appElement = "body";
+    Modal.setAppElement(appElement);
+    ReactDOM.render(<App />, node);
+    document.body
+      .querySelector(".ReactModalPortal")
+      .parentNode.should.be.eql(document.body);
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
   it("default parentSelector should be document.body.", () => {
     const modal = renderModal({ isOpen: true });
     modal.props.parentSelector().should.be.eql(document.body);

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -84,7 +84,7 @@ export default () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  it("allows setting appElement of type string", () => {
+  it("allow setting appElement of type string", () => {
     const node = document.createElement("div");
     class App extends Component {
       render() {

--- a/src/helpers/ariaAppHider.js
+++ b/src/helpers/ariaAppHider.js
@@ -1,4 +1,5 @@
 import warning from "warning";
+import { canUseDOM } from "./safeHTMLElement";
 
 let globalElement = null;
 
@@ -12,7 +13,7 @@ export function assertNodeList(nodeList, selector) {
 
 export function setElement(element) {
   let useElement = element;
-  if (typeof useElement === "string") {
+  if (typeof useElement === "string" && canUseDOM) {
     const el = document.querySelectorAll(useElement);
     assertNodeList(el, useElement);
     useElement = "length" in el ? el[0] : el;


### PR DESCRIPTION
Fixes #580 .
Related to #576.

Changes proposed:

- Added missing uncovered test for the scenario when a user wants to use `ReactModal.setElement("some_element"), i.e. on a string type appElement.
- Added some safety check in settlement method when there is no document due to ssr for example. It actually broke my project which uses ssr. I don't see any tests for ssr, but if for some reasons I missed them, I will be more than happy to add a test for my change.

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed. - Not needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above. - Not relevant
