### PR TITLE
Remove aria-modal attribute to prevent browser bugs

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -334,7 +334,6 @@ export default class ModalPortal extends Component {
         style={{ ...overlayStyles, ...this.props.style.overlay }}
         onClick={this.handleOverlayOnClick}
         onMouseDown={this.handleOverlayOnMouseDown}
-        aria-modal="true"
       >
         <div
           ref={this.setContentRef}


### PR DESCRIPTION
Fixes #654.

Changes proposed:

- remove the `aria-modal` attribute set on the modal wrapper

There are a couple problems with the aria-modal attribute:

- it is not set on the correct dom element (in theory, it should be
set on the element having the dialog role, as stated in #654)
- it is buggy in Safari. The easy way to fix the problem is to remove the attribute
(again, as suggested in #654). While it's cool on paper, the attribute is currently
not necessary, since the `aria-hidden="true"` is set correctly on the
app element.

~Upgrade Path (for changed or removed APIs):~


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed. *There were no changes needed*
- [x] If this is a code change, a spec testing the functionality has been added. *As there were no test about the presence of aria-modal before, I did not change anything*
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
