### PR TITLE
[fixed] set default role for accessibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,7 @@ import ReactModal from 'react-modal';
   shouldReturnFocusAfterClose={true}
   /*
     String indicating the role of the modal, allowing the 'dialog' role to be applied if desired.
+    This attribute is `dialog` by default.
   */
   role="dialog"
   /*

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -117,6 +117,19 @@ export default () => {
     contentAttribute(modal, "role").should.be.eql("dialog");
   });
 
+  // eslint-disable-next-line max-len
+  it("renders the modal content with the default aria role when not provided", () => {
+    const child = "I am a child of Modal, and he has sent me here...";
+    const modal = renderModal({ isOpen: true }, child);
+    contentAttribute(modal, "role").should.be.eql("dialog");
+  });
+
+  it("does not render the aria role when provided role with null", () => {
+    const child = "I am a child of Modal, and he has sent me here...";
+    const modal = renderModal({ isOpen: true, role: null }, child);
+    should(contentAttribute(modal, "role")).be.eql(null);
+  });
+
   it("sets aria-label based on the contentLabel prop", () => {
     const child = "I am a child of Modal, and he has sent me here...";
     const modal = renderModal(

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -73,6 +73,7 @@ class Modal extends Component {
     isOpen: false,
     portalClassName,
     bodyOpenClassName,
+    role: "dialog",
     ariaHideApp: true,
     closeTimeoutMS: 0,
     shouldFocusAfterRender: true,


### PR DESCRIPTION
Fixes #653 .

Changes proposed:

- Set default value for `role`

As @afercia suggested, we should set a default value for the dialog. And omit it entirely when passing `null`.

Upgrade Path (for changed or removed APIs):
No API changed

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
