### PR TITLE
[fixed] check if element exists before focusing in scopeTab helper

### DIFF
--- a/src/helpers/scopeTab.js
+++ b/src/helpers/scopeTab.js
@@ -63,8 +63,13 @@ export default function scopeTab(node, event) {
   }
 
   // If the tabbable element does not exist,
-  // let the browser control the focus
-  if (typeof tabbable[x] === "undefined") return;
+  // focus head/tail based on shiftKey
+  if (typeof tabbable[x] === "undefined") {
+    event.preventDefault();
+    target = shiftKey ? tail : head;
+    target.focus();
+    return;
+  }
 
   event.preventDefault();
 

--- a/src/helpers/scopeTab.js
+++ b/src/helpers/scopeTab.js
@@ -62,6 +62,10 @@ export default function scopeTab(node, event) {
     x += shiftKey ? -1 : 1;
   }
 
+  // If the tabbable element does not exist,
+  // let the browser control the focus
+  if (typeof tabbable[x] === "undefined") return;
+
   event.preventDefault();
 
   tabbable[x].focus();


### PR DESCRIPTION
Fixes #687

Changes proposed:
- check if element is undefined before focusing it

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
