### PR TITLE
[fixed] Render `testId` property

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -417,6 +417,14 @@ export default () => {
     unmountModal();
   });
 
+  it("additional testId attribute", () => {
+    const modal = renderModal({ isOpen: true, testId: "foo-bar" }, "hello");
+    mcontent(modal)
+      .getAttribute("data-testid")
+      .should.be.eql("foo-bar");
+    unmountModal();
+  });
+
   it("raises an exception if the appElement selector does not match", () => {
     should(() => ariaAppHider.setElement(".test")).throw();
   });

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -348,6 +348,7 @@ export default class ModalPortal extends Component {
           aria-label={this.props.contentLabel}
           {...this.attributesFromObject("aria", this.props.aria || {})}
           {...this.attributesFromObject("data", this.props.data || {})}
+          data-testid={this.props.testId}
         >
           {this.props.children}
         </div>


### PR DESCRIPTION
Fixes https://github.com/reactjs/react-modal/issues/694

Changes proposed:

- Render `testId` prop to DOM as `data-testid={this.props.testId}` as originally implemented in: https://github.com/reactjs/react-modal/pull/646

Upgrade Path (for changed or removed APIs):

N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
