### PR TITLE
[removed] Redundant prop `testId`

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -55,8 +55,7 @@ export default class ModalPortal extends Component {
     children: PropTypes.node,
     shouldCloseOnEsc: PropTypes.bool,
     overlayRef: PropTypes.func,
-    contentRef: PropTypes.func,
-    testId: PropTypes.string
+    contentRef: PropTypes.func
   };
 
   constructor(props) {


### PR DESCRIPTION
Fixes https://github.com/reactjs/react-modal/issues/694

Changes proposed:

- Remove redundant prop `testId` which no longer renders to DOM

Upgrade Path (for changed or removed APIs):
- Use `data` prop instead

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
