### PR TITLE
Change browser from Chrome to ChromeHeadless

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-let browsers = ['Chrome'];
+let browsers = ['ChromeHeadless'];
 let coverageType = 'text';
 
 if (process.env.CONTINUOUS_INTEGRATION) {


### PR DESCRIPTION
Changing the browser from Chrome to ChromeHeadless 

As when using chromium binary to launch chrome then getting issues
```
15 10 2018 09:29:34.292:ERROR [launcher]: Cannot start Chrome

15 10 2018 09:29:34.292:ERROR [launcher]: Chrome stdout:
15 10 2018 09:29:34.292:ERROR [launcher]: Chrome stderr:
15 10 2018 09:29:34.298:INFO [launcher]: Trying to start Chrome again (1/2).
15 10 2018 09:29:35.145:ERROR [launcher]: Cannot start Chrome

15 10 2018 09:29:35.145:ERROR [launcher]: Chrome stdout:
15 10 2018 09:29:35.146:ERROR [launcher]: Chrome stderr:
15 10 2018 09:29:35.146:INFO [launcher]: Trying to start Chrome again (2/2).
15 10 2018 09:29:35.993:ERROR [launcher]: Cannot start Chrome

15 10 2018 09:29:35.994:ERROR [launcher]: Chrome stdout:
15 10 2018 09:29:35.994:ERROR [launcher]: Chrome stderr:
15 10 2018 09:29:35.995:ERROR [launcher]: Chrome failed 2 times (cannot start). Giving up.
```
But, if using chromeHeadless in place of Chrome then the browser launches

Headless browsers provide automated control of a web page in an environment similar to popular web browsers, but are executed via a command-line interface or using network communication

Signed-off-by: ossdev <ossdev@puresoftware.com>

Fixes #[issue number].

Changes proposed:
Changing browser from chrome to chrome headless 

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
