### PR TITLE
[fixed] Allow ReactDOM.createPortal to be mocked in tests

### DIFF
--- a/specs/Modal.testability.spec.js
+++ b/specs/Modal.testability.spec.js
@@ -1,10 +1,6 @@
 import ReactDOM from "react-dom";
 import sinon from "sinon";
-import {
-  mcontent,
-  renderModal,
-  emptyDOM
-} from "./helper";
+import { mcontent, renderModal, emptyDOM } from "./helper";
 
 export default () => {
   afterEach("cleaned up all rendered modals", emptyDOM);

--- a/specs/Modal.testability.spec.js
+++ b/specs/Modal.testability.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import ReactDOM from "react-dom";
 import sinon from "sinon";
 import { mcontent, renderModal, emptyDOM } from "./helper";

--- a/specs/Modal.testability.spec.js
+++ b/specs/Modal.testability.spec.js
@@ -1,0 +1,23 @@
+import ReactDOM from "react-dom";
+import sinon from "sinon";
+import {
+  mcontent,
+  renderModal,
+  emptyDOM
+} from "./helper";
+
+export default () => {
+  afterEach("cleaned up all rendered modals", emptyDOM);
+
+  it("renders as expected, initially", () => {
+    const modal = renderModal({ isOpen: true }, "hello");
+    mcontent(modal).should.be.ok();
+  });
+
+  it("allows ReactDOM.createPortal to be overridden in real-time", () => {
+    const createPortalSpy = sinon.spy(ReactDOM, "createPortal");
+    renderModal({ isOpen: true }, "hello");
+    createPortalSpy.called.should.be.ok();
+    ReactDOM.createPortal.restore();
+  });
+};

--- a/specs/index.js
+++ b/specs/index.js
@@ -4,8 +4,10 @@ import ModalState from "./Modal.spec";
 import ModalEvents from "./Modal.events.spec";
 import ModalStyle from "./Modal.style.spec";
 import ModalHelpers from "./Modal.helpers.spec";
+import ModalTestability from "./Modal.testability.spec";
 
 describe("State", ModalState);
 describe("Style", ModalStyle);
 describe("Events", ModalEvents);
 describe("Helpers", ModalHelpers);
+describe("Testability", ModalTestability);

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,9 +11,11 @@ export const portalClassName = "ReactModalPortal";
 export const bodyOpenClassName = "ReactModal__Body--open";
 
 const isReact16 = ReactDOM.createPortal !== undefined;
-const createPortal = isReact16
-  ? ReactDOM.createPortal
-  : ReactDOM.unstable_renderSubtreeIntoContainer;
+
+const getCreatePortal = () =>
+  isReact16
+    ? ReactDOM.createPortal
+    : ReactDOM.unstable_renderSubtreeIntoContainer;
 
 function getParentElement(parentSelector) {
   return parentSelector();
@@ -180,6 +182,7 @@ class Modal extends Component {
   };
 
   renderPortal = props => {
+    const createPortal = getCreatePortal();
     const portal = createPortal(
       this,
       <ModalPortal defaultStyles={Modal.defaultStyles} {...props} />,
@@ -197,6 +200,7 @@ class Modal extends Component {
       this.node = document.createElement("div");
     }
 
+    const createPortal = getCreatePortal();
     return createPortal(
       <ModalPortal
         ref={this.portalRef}


### PR DESCRIPTION
Fixes #553

See the [related comment](https://github.com/reactjs/react-modal/issues/553#issuecomment-429698010).

Changes proposed:

- Move `createPortal` method-resolution inside a method so that it can be determined at the time that it is needed. This allows developers to mock out `ReactDOM.createPortal` inside tests, which can be needed for various reasons including [react-test-renderer not supporting portals](https://github.com/facebook/react/issues/11565).

Upgrade Path (for changed or removed APIs):

N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
