### PR TITLE
[added] isNested prop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,11 @@ import ReactModal from 'react-modal';
   */
   isOpen={false}
   /*
+    Boolean flagging whether the current modal is nested (i.e., multiple
+    modals staked on top of each other).
+  */
+  isNested={false}
+  /*
     Function that will be run after the modal has opened.
   */
   onAfterOpen={handleAfterOpenFunc}

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -46,6 +46,7 @@ export default () => {
     const modal = ReactDOM.render(<Modal />, node);
     const props = modal.props;
     props.isOpen.should.not.be.ok();
+    props.isNested.should.not.be.ok();
     props.ariaHideApp.should.be.ok();
     props.closeTimeoutMS.should.be.eql(0);
     props.shouldFocusAfterRender.should.be.ok();

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -65,12 +65,14 @@ class Modal extends Component {
     contentLabel: PropTypes.string,
     shouldCloseOnEsc: PropTypes.bool,
     overlayRef: PropTypes.func,
-    contentRef: PropTypes.func
+    contentRef: PropTypes.func,
+    isNested: PropTypes.bool
   };
   /* eslint-enable react/no-unused-prop-types */
 
   static defaultProps = {
     isOpen: false,
+    isNested: false,
     portalClassName,
     bodyOpenClassName,
     role: "dialog",

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -156,7 +156,7 @@ export default class ModalPortal extends Component {
       ariaHideApp,
       htmlOpenClassName,
       bodyOpenClassName,
-      isNested,
+      isNested
     } = this.props;
 
     // only remove the covering className is the modal is not nested;

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -28,6 +28,7 @@ export default class ModalPortal extends Component {
 
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
+    isNested: PropTypes.bool.isRequired,
     defaultStyles: PropTypes.shape({
       content: PropTypes.object,
       overlay: PropTypes.object
@@ -154,17 +155,23 @@ export default class ModalPortal extends Component {
       appElement,
       ariaHideApp,
       htmlOpenClassName,
-      bodyOpenClassName
+      bodyOpenClassName,
+      isNested,
     } = this.props;
 
-    // Remove classes.
-    classList.remove(document.body, bodyOpenClassName);
+    // only remove the covering className is the modal is not nested;
+    // if nested, the remaining Russian doll modals will need the
+    // covering className
+    if (!isNested) {
+      // Remove classes.
+      classList.remove(document.body, bodyOpenClassName);
 
-    htmlOpenClassName &&
-      classList.remove(
-        document.getElementsByTagName("html")[0],
-        htmlOpenClassName
-      );
+      htmlOpenClassName &&
+        classList.remove(
+          document.getElementsByTagName("html")[0],
+          htmlOpenClassName
+        );
+    }
 
     // Reset aria-hidden attribute if all modals have been removed
     if (ariaHideApp && ariaHiddenInstances > 0) {


### PR DESCRIPTION

Changes proposed:
- adds `isNested: bool` (optional) prop, which gives you the option of not removing the modal backdrop.

**Why?** This enables Russian doll nesting, so you can have multiple modals open on top of each other.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
