### PR TITLE
[added] Added custom overlayElement and contentElement.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,14 @@ import ReactModal from 'react-modal';
     Content ref callback.
   */
   contentRef={setContentRef}
+  /*
+    Custom Overlay element.
+  */
+  overlayElement={(props, contentElement) => <div {...props}>{contentElement}</div>}
+  /*
+    Custom Content element.
+  */
+  contentElement={(props, children) => <div {...props}>{children}</div>}
 />
 ```
 

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -65,6 +65,7 @@ export default () => {
 
   it("renders into the body, not in context", () => {
     const node = document.createElement("div");
+
     class App extends Component {
       render() {
         return (
@@ -76,6 +77,7 @@ export default () => {
         );
       }
     }
+
     Modal.setAppElement(node);
     ReactDOM.render(<App />, node);
     document.body
@@ -86,6 +88,7 @@ export default () => {
 
   it("allow setting appElement of type string", () => {
     const node = document.createElement("div");
+
     class App extends Component {
       render() {
         return (
@@ -97,6 +100,7 @@ export default () => {
         );
       }
     }
+
     const appElement = "body";
     Modal.setAppElement(appElement);
     ReactDOM.render(<App />, node);
@@ -188,6 +192,7 @@ export default () => {
       unmountModal();
       done();
     }
+
     const modalA = renderModal(
       {
         isOpen: true,
@@ -245,6 +250,33 @@ export default () => {
     mcontent(modal)
       .className.includes("myClass")
       .should.be.ok();
+  });
+
+  it("supports custom overlayElement", () => {
+    const overlayElement = (props, contentElement) => (
+      <div id="custom" {...props}>
+        {contentElement}
+      </div>
+    );
+
+    const modal = renderModal({ isOpen: true, overlayElement });
+    const modalOverlay = moverlay(modal);
+
+    modalOverlay.id.should.eql("custom");
+  });
+
+  it("supports custom contentElement", () => {
+    const contentElement = (props, children) => (
+      <div id="custom" {...props}>
+        {children}
+      </div>
+    );
+
+    const modal = renderModal({ isOpen: true, contentElement }, "hello");
+    const modalContent = mcontent(modal);
+
+    modalContent.id.should.eql("custom");
+    modalContent.textContent.should.be.eql("hello");
   });
 
   it("supports overlayClassName", () => {
@@ -611,13 +643,16 @@ export default () => {
         super(props);
         this.state = { error: false };
       }
+
       unstable_handleError() {
         this.setState({ error: true });
       }
+
       render() {
         return this.state.error ? null : <div>{this.props.children}</div>;
       }
     }
+
     /* eslint-enable camelcase, react/prop-types */
 
     const Throw = () => {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -67,7 +67,9 @@ class Modal extends Component {
     contentLabel: PropTypes.string,
     shouldCloseOnEsc: PropTypes.bool,
     overlayRef: PropTypes.func,
-    contentRef: PropTypes.func
+    contentRef: PropTypes.func,
+    overlayElement: PropTypes.func,
+    contentElement: PropTypes.func
   };
   /* eslint-enable react/no-unused-prop-types */
 
@@ -82,7 +84,9 @@ class Modal extends Component {
     shouldCloseOnEsc: true,
     shouldCloseOnOverlayClick: true,
     shouldReturnFocusAfterClose: true,
-    parentSelector: () => document.body
+    parentSelector: () => document.body,
+    overlayElement: (props, contentEl) => <div {...props}>{contentEl}</div>,
+    contentElement: (props, children) => <div {...props}>{children}</div>
   };
 
   static defaultStyles = {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import * as focusManager from "../helpers/focusManager";
 import scopeTab from "../helpers/scopeTab";
@@ -56,6 +56,8 @@ export default class ModalPortal extends Component {
     shouldCloseOnEsc: PropTypes.bool,
     overlayRef: PropTypes.func,
     contentRef: PropTypes.func,
+    overlayElement: PropTypes.func,
+    contentElement: PropTypes.func,
     testId: PropTypes.string
   };
 
@@ -323,36 +325,39 @@ export default class ModalPortal extends Component {
     }, {});
 
   render() {
-    const { className, overlayClassName, defaultStyles } = this.props;
+    const { className, overlayClassName, defaultStyles, children } = this.props;
     const contentStyles = className ? {} : defaultStyles.content;
     const overlayStyles = overlayClassName ? {} : defaultStyles.overlay;
 
-    return this.shouldBeClosed() ? null : (
-      <div
-        ref={this.setOverlayRef}
-        className={this.buildClassName("overlay", overlayClassName)}
-        style={{ ...overlayStyles, ...this.props.style.overlay }}
-        onClick={this.handleOverlayOnClick}
-        onMouseDown={this.handleOverlayOnMouseDown}
-      >
-        <div
-          ref={this.setContentRef}
-          style={{ ...contentStyles, ...this.props.style.content }}
-          className={this.buildClassName("content", className)}
-          tabIndex="-1"
-          onKeyDown={this.handleKeyDown}
-          onMouseDown={this.handleContentOnMouseDown}
-          onMouseUp={this.handleContentOnMouseUp}
-          onClick={this.handleContentOnClick}
-          role={this.props.role}
-          aria-label={this.props.contentLabel}
-          {...this.attributesFromObject("aria", this.props.aria || {})}
-          {...this.attributesFromObject("data", this.props.data || {})}
-          data-testid={this.props.testId}
-        >
-          {this.props.children}
-        </div>
-      </div>
-    );
+    if (this.shouldBeClosed()) {
+      return null;
+    }
+
+    const overlayProps = {
+      ref: this.setOverlayRef,
+      className: this.buildClassName("overlay", overlayClassName),
+      style: { ...overlayStyles, ...this.props.style.overlay },
+      onClick: this.handleOverlayOnClick,
+      onMouseDown: this.handleOverlayOnMouseDown
+    };
+
+    const contentProps = {
+      ref: this.setContentRef,
+      style: { ...contentStyles, ...this.props.style.content },
+      className: this.buildClassName("content", className),
+      tabIndex: "-1",
+      onKeyDown: this.handleKeyDown,
+      onMouseDown: this.handleContentOnMouseDown,
+      onMouseUp: this.handleContentOnMouseUp,
+      onClick: this.handleContentOnClick,
+      role: this.props.role,
+      "aria-label": this.props.contentLabel,
+      ...this.attributesFromObject("aria", this.props.aria || {}),
+      ...this.attributesFromObject("data", this.props.data || {}),
+      "data-testid": this.props.testId
+    };
+
+    const contentElement = this.props.contentElement(contentProps, children);
+    return this.props.overlayElement(overlayProps, contentElement);
   }
 }


### PR DESCRIPTION
Changes proposed:

- Adding `overlayElement` and `contentElement` to provide control over what DOM Element can be used for each.

**Why?** Not limited to using just `<div>`. Easier to add custom props to each element, e.g `id`, `onScroll`, etc...


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
