### PR TITLE
[added] Introduce onAfterClose callback prop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,10 @@ import ReactModal from 'react-modal';
   */
   onAfterOpen={handleAfterOpenFunc}
   /*
+    Function that will be run after the modal has closed.
+  */
+  onAfterClose={handleAfterCloseFunc}
+  /*
     Function that will be run when the modal is requested to be closed (either by clicking on overlay or pressing ESC)
     Note: It is not called if isOpen is changed by other means.
   */

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -24,7 +24,7 @@ export default () => {
     afterOpenCallback.called.should.be.ok();
   });
 
-  it.only("should trigger the onAfterClose callback", () => {
+  it("should trigger the onAfterClose callback", () => {
     const onAfterCloseCallback = sinon.spy();
     const modal = renderModal({
       isOpen: true,

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -24,6 +24,18 @@ export default () => {
     afterOpenCallback.called.should.be.ok();
   });
 
+  it.only("should trigger the onAfterClose callback", () => {
+    const onAfterCloseCallback = sinon.spy();
+    const modal = renderModal({
+      isOpen: true,
+      onAfterClose: onAfterCloseCallback
+    });
+
+    modal.portal.close();
+
+    onAfterCloseCallback.called.should.be.ok();
+  });
+
   it("keeps focus inside the modal when child has no tabbable elements", () => {
     let tabPrevented = false;
     const modal = renderModal({ isOpen: true }, "hello");

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -43,6 +43,7 @@ export default class ModalPortal extends Component {
     ariaHideApp: PropTypes.bool,
     appElement: PropTypes.instanceOf(SafeHTMLElement),
     onAfterOpen: PropTypes.func,
+    onAfterClose: PropTypes.func,
     onRequestClose: PropTypes.func,
     closeTimeoutMS: PropTypes.number,
     shouldFocusAfterRender: PropTypes.bool,
@@ -182,6 +183,10 @@ export default class ModalPortal extends Component {
       } else {
         focusManager.popWithoutFocus();
       }
+    }
+
+    if (this.props.onAfterClose) {
+      this.props.onAfterClose();
     }
   };
 


### PR DESCRIPTION
Fixes #708 .

Since the `onRequestClose` won't be executed when `isOpen` changes outside of the controller scope, I think it's reasonable to give a single handler to general closing.

This would allow for some more centralised solutions like:

```js
const modalProps = {
  onAfterOpen: disableBodyScroll,
  onAfterClose: enableBodyScroll,
}
```

whereas today you have to do:

```js
const modalProps = {
  onAfterOpen: disableBodyScroll,
  onRequestClose:  enableBodyScroll
}

closeModal () {
  this.setState({ isOpen: false })
  enableBodyScroll();
}
```

Changes proposed:

- Introduce `onAfterClose` callback prop

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
