### PR TITLE
[fixed] Can't close Modal B on examples

### DIFF
--- a/examples/basic/nested_modals/index.js
+++ b/examples/basic/nested_modals/index.js
@@ -34,7 +34,7 @@ class Item extends Component {
                  labelledby: "item_title",
                  describedby: "item_info"
                }}>
-          <h1 id="item_title">Item: {itemNumber}</h1>
+          <h1 id="item_title">Item: {itemNumber + 1}</h1>
           <div id="item_info">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar varius auctor. Aliquam maximus et justo ut faucibus. Nullam sit amet urna molestie turpis bibendum accumsan a id sem. Proin ullamcorper nisl sapien, gravida dictum nibh congue vel. Vivamus convallis dolor vitae ipsum ultricies, vitae pulvinar justo tincidunt. Maecenas a nunc elit. Phasellus fermentum, tellus ut consectetur scelerisque, eros nunc lacinia eros, aliquet efficitur tellus arcu a nibh. Praesent quis consequat nulla. Etiam dapibus ac sem vel efficitur. Nunc faucibus efficitur leo vitae vulputate. Nunc at quam vitae felis pretium vehicula vel eu quam. Quisque sapien mauris, condimentum eget dictum ut, congue id dolor. Donec vitae varius orci, eu faucibus turpis. Morbi eleifend orci non urna bibendum, ac scelerisque augue efficitur.</p>
           </div>

--- a/examples/basic/simple_usage/index.js
+++ b/examples/basic/simple_usage/index.js
@@ -82,6 +82,7 @@ class SimpleUsage extends Component {
           <h1 id="heading" ref={h1 => this.heading = h1}>This is the modal 2!</h1>
           <div id="fulldescription" tabIndex="0" role="document">
             <p>This is a description of what it does: nothing :)</p>
+            <button onClick={this.toggleModal(MODAL_B)}>close</button>
           </div>
         </Modal>
       </div>


### PR DESCRIPTION
Fixes #725.

Changes proposed:

- can close modal B with close button

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
