### PR TITLE
Prevent scrolling in Chrome after closing dialog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,11 @@ import ReactModal from 'react-modal';
   */
   shouldReturnFocusAfterClose={true}
   /*
+    Boolean indicating if the modal should use the preventScroll flag when restoring focus
+    to the element that had focus prior to its display.
+  */
+  preventScroll={false}
+  /*
     String indicating the role of the modal, allowing the 'dialog' role to be applied if desired.
     This attribute is `dialog` by default.
   */

--- a/examples/basic/nested_modals/index.js
+++ b/examples/basic/nested_modals/index.js
@@ -34,7 +34,7 @@ class Item extends Component {
                  labelledby: "item_title",
                  describedby: "item_info"
                }}>
-          <h1 id="item_title">Item: {itemNumber}</h1>
+          <h1 id="item_title">Item: {itemNumber + 1}</h1>
           <div id="item_info">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar varius auctor. Aliquam maximus et justo ut faucibus. Nullam sit amet urna molestie turpis bibendum accumsan a id sem. Proin ullamcorper nisl sapien, gravida dictum nibh congue vel. Vivamus convallis dolor vitae ipsum ultricies, vitae pulvinar justo tincidunt. Maecenas a nunc elit. Phasellus fermentum, tellus ut consectetur scelerisque, eros nunc lacinia eros, aliquet efficitur tellus arcu a nibh. Praesent quis consequat nulla. Etiam dapibus ac sem vel efficitur. Nunc faucibus efficitur leo vitae vulputate. Nunc at quam vitae felis pretium vehicula vel eu quam. Quisque sapien mauris, condimentum eget dictum ut, congue id dolor. Donec vitae varius orci, eu faucibus turpis. Morbi eleifend orci non urna bibendum, ac scelerisque augue efficitur.</p>
           </div>

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -51,6 +51,7 @@ export default () => {
     props.closeTimeoutMS.should.be.eql(0);
     props.shouldFocusAfterRender.should.be.ok();
     props.shouldCloseOnOverlayClick.should.be.ok();
+    props.preventScroll.should.be.false();
     ReactDOM.unmountComponentAtNode(node);
     ariaAppHider.resetForTesting();
     Modal.setAppElement(document.body); // restore default

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -60,6 +60,7 @@ class Modal extends Component {
     shouldFocusAfterRender: PropTypes.bool,
     shouldCloseOnOverlayClick: PropTypes.bool,
     shouldReturnFocusAfterClose: PropTypes.bool,
+    preventScroll: PropTypes.bool,
     parentSelector: PropTypes.func,
     aria: PropTypes.object,
     data: PropTypes.object,
@@ -82,6 +83,7 @@ class Modal extends Component {
     shouldCloseOnEsc: true,
     shouldCloseOnOverlayClick: true,
     shouldReturnFocusAfterClose: true,
+    preventScroll: false,
     parentSelector: () => document.body
   };
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -49,6 +49,7 @@ export default class ModalPortal extends Component {
     shouldFocusAfterRender: PropTypes.bool,
     shouldCloseOnOverlayClick: PropTypes.bool,
     shouldReturnFocusAfterClose: PropTypes.bool,
+    preventScroll: PropTypes.bool,
     role: PropTypes.string,
     contentLabel: PropTypes.string,
     aria: PropTypes.object,
@@ -178,7 +179,7 @@ export default class ModalPortal extends Component {
 
     if (this.props.shouldFocusAfterRender) {
       if (this.props.shouldReturnFocusAfterClose) {
-        focusManager.returnFocus();
+        focusManager.returnFocus(this.props.preventScroll);
         focusManager.teardownScopedFocus();
       } else {
         focusManager.popWithoutFocus();

--- a/src/helpers/focusManager.js
+++ b/src/helpers/focusManager.js
@@ -39,7 +39,7 @@ export function returnFocus() {
   try {
     if (focusLaterElements.length !== 0) {
       toFocus = focusLaterElements.pop();
-      toFocus.focus();
+      toFocus.focus({ preventScroll: true });
     }
     return;
   } catch (e) {

--- a/src/helpers/focusManager.js
+++ b/src/helpers/focusManager.js
@@ -34,12 +34,12 @@ export function markForFocusLater() {
 }
 
 /* eslint-disable no-console */
-export function returnFocus() {
+export function returnFocus(preventScroll = false) {
   let toFocus = null;
   try {
     if (focusLaterElements.length !== 0) {
       toFocus = focusLaterElements.pop();
-      toFocus.focus({ preventScroll: true });
+      toFocus.focus({ preventScroll });
     }
     return;
   } catch (e) {


### PR DESCRIPTION
Prevent scrolling in Chrome when returning focus to the previous active element when closing the dialog

Fixes #735 

Changes proposed:

- Add the `{ preventScroll: true }` option object to the focus call.

Upgrade Path (for changed or removed APIs):
N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
