### PR TITLE
[added]: pass overlay and content element references to onAfterOpen fn

### DIFF
--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -24,6 +24,16 @@ export default () => {
     afterOpenCallback.called.should.be.ok();
   });
 
+  it("should call onAfterOpen with overlay and content references", () => {
+    const afterOpenCallback = sinon.spy();
+    const modal = renderModal({ isOpen: true, onAfterOpen: afterOpenCallback });
+
+    sinon.assert.calledWith(afterOpenCallback, {
+      overlayEl: modal.portal.overlay,
+      contentEl: modal.portal.content
+    });
+  });
+
   it("should trigger the onAfterClose callback", () => {
     const onAfterCloseCallback = sinon.spy();
     const modal = renderModal({

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -205,7 +205,10 @@ export default class ModalPortal extends Component {
         this.setState({ afterOpen: true });
 
         if (this.props.isOpen && this.props.onAfterOpen) {
-          this.props.onAfterOpen();
+          this.props.onAfterOpen({
+            overlayEl: this.overlay,
+            contentEl: this.content
+          });
         }
       });
     }


### PR DESCRIPTION
Fixes #739 .

Changes proposed:

- Pass `overlay` and `content` references to `onAfterOpen` prop fn

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
