### PR TITLE
📗 put example of overlay custom style in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ import ReactDOM from 'react-dom';
 import Modal from 'react-modal';
 
 const customStyles = {
+  overlay : {
+    backgroundColor       : 'rgba(0, 0, 0, 0.5)'
+  },
   content : {
     top                   : '50%',
     left                  : '50%',


### PR DESCRIPTION
Changes proposed:

Add overlay custom style in README so people don't need to go digging through the docs just to find the right keyname

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
