### PR TITLE
Hot reload removing portal node on storybook.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -174,7 +174,7 @@ class Modal extends Component {
   removePortal = () => {
     !isReact16 && ReactDOM.unmountComponentAtNode(this.node);
     const parent = getParentElement(this.props.parentSelector);
-    parent.removeChild(this.node);
+    parent && parent.removeChild(this.node);
   };
 
   portalRef = ref => {


### PR DESCRIPTION
In a storybook the hot reload removes the parent before the .removeChild, which makes this mistake once in two:
`Can not read property 'removeChild' of null`