### PR TITLE
[fixed] onAfterClose prop called when unmounting a closed modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ scripts/__pycache__/
 examples/**/*-bundle.js
 node_modules/
 .idea/
+.vscode
 _book
 *.patch
 *.diff

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -12,7 +12,8 @@ import {
   escKeyDown,
   tabKeyDown,
   renderModal,
-  emptyDOM
+  emptyDOM,
+  unmountModal
 } from "./helper";
 
 export default () => {
@@ -33,6 +34,20 @@ export default () => {
 
     modal.portal.close();
 
+    onAfterCloseCallback.called.should.be.ok();
+  });
+
+  it("should not trigger onAfterClose callback when unmounting a closed modal", () => {
+    const onAfterCloseCallback = sinon.spy();
+    renderModal({ isOpen: false, onAfterClose: onAfterCloseCallback });
+    unmountModal();
+    onAfterCloseCallback.called.should.not.be.ok();
+  });
+
+  it("should trigger onAfterClose callback when unmounting an opened modal", () => {
+    const onAfterCloseCallback = sinon.spy();
+    renderModal({ isOpen: true, onAfterClose: onAfterCloseCallback });
+    unmountModal();
     onAfterCloseCallback.called.should.be.ok();
   });
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -113,7 +113,9 @@ export default class ModalPortal extends Component {
   }
 
   componentWillUnmount() {
-    this.afterClose();
+    if (this.state.isOpen) {
+      this.afterClose();
+    }
     clearTimeout(this.closeTimer);
   }
 


### PR DESCRIPTION
Fixes #745

Changes proposed:

- `onAfterClose` prop will no longer be triggered when unmounting a closed modal, but will still be when unmounting an opened modal.
- Added `.vscode` folder to `.gitignore`

Upgrade Path (for changed or removed APIs): N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
