### PR TITLE
[fixed] some untabbable elements are being returned from findTabbable

### DIFF
--- a/specs/Modal.helpers.spec.js
+++ b/specs/Modal.helpers.spec.js
@@ -105,6 +105,15 @@ export default () => {
         elem.appendChild(input);
         tabbable(elem).should.containEql(input);
       });
+
+      it("excludes elements with overflow == visible if there is no visible content", () => {
+        const button = document.createElement("button");
+        button.innerHTML = "You can't see me!";
+        button.style.display = "none";
+        button.style.overflow = "visible";
+        elem.appendChild(button);
+        tabbable(elem).should.not.containEql(button);
+      });
     });
   });
 };

--- a/specs/Modal.helpers.spec.js
+++ b/specs/Modal.helpers.spec.js
@@ -99,9 +99,9 @@ export default () => {
 
       it("includes inputs visible because of overflow == visible", () => {
         const input = document.createElement("input");
-        elem.style.width = "0";
-        elem.style.height = "0";
-        elem.style.overflow = "visible";
+        input.style.width = "0";
+        input.style.height = "0";
+        input.style.overflow = "visible";
         elem.appendChild(input);
         tabbable(elem).should.containEql(input);
       });

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -21,7 +21,9 @@ function hidesContents(element) {
   // Otherwise we need to check some styles
   const style = window.getComputedStyle(element);
   return zeroSize
-    ? style.getPropertyValue("overflow") !== "visible"
+    ? style.getPropertyValue("overflow") !== "visible" ||
+        // if 'overflow: visible' set, check if there is actually any overflow
+        (element.scrollWidth <= 0 && element.scrollHeight <= 0)
     : style.getPropertyValue("display") == "none";
 }
 


### PR DESCRIPTION
Fixes #732 

Changes proposed:

The bug in the example stems from the `hidesContents` function in `tabbable.js` returning false on the button with the `display: none` inline style. It is returning false because the element has the computed style `overflow: visible` (which is default value). 

The problem with this is that having `overflow: visible` doesn't mean there is any content that is  overflowing. 

I think there are a couple possible ways to fix this. One would be to add an additional check for the `display: none` style if `zeroSize === true`, which would directly solve the bug in the example.

I'm not sure that will catch every possibility, so instead I check the elements `scrollWidth` and `scrollHeight` to determine whether or not there is any overflowing content.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] If this is a code change, a spec testing the functionality has been added.