### PR TITLE
[Fixed] Screen readers cannot access components without ariaHideApp

### DIFF
--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -47,7 +47,7 @@ export default () => {
     const modal = ReactDOM.render(<Modal />, node);
     const props = modal.props;
     props.isOpen.should.not.be.ok();
-    props.ariaHideApp.should.be.ok();
+    props.ariaHideApp.should.not.be.ok();
     props.closeTimeoutMS.should.be.eql(0);
     props.shouldFocusAfterRender.should.be.ok();
     props.shouldCloseOnOverlayClick.should.be.ok();

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -76,7 +76,7 @@ class Modal extends Component {
     portalClassName,
     bodyOpenClassName,
     role: "dialog",
-    ariaHideApp: true,
+    ariaHideApp: false,
     closeTimeoutMS: 0,
     shouldFocusAfterRender: true,
     shouldCloseOnEsc: true,


### PR DESCRIPTION

Fixes #776 
I updated the default props spec, but I am not sure if it is enough.

Changes proposed:

- Changing the default props "ariaHideApp" to false.

Upgrade Path (for changed or removed APIs):
none

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
