### PR TITLE
[fixed] Call parent.removeChild only if parent exists

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -174,7 +174,14 @@ class Modal extends Component {
   removePortal = () => {
     !isReact16 && ReactDOM.unmountComponentAtNode(this.node);
     const parent = getParentElement(this.props.parentSelector);
-    parent && parent.removeChild(this.node);
+    if (parent) {
+      parent.removeChild(this.node);
+    } else {
+      /* eslint-disable-next-line no-console  */
+      console.warn(
+        "Cannot remove modal from the parent element as it no longer exists in the DOM"
+      );
+    }
   };
 
   portalRef = ref => {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -174,7 +174,7 @@ class Modal extends Component {
   removePortal = () => {
     !isReact16 && ReactDOM.unmountComponentAtNode(this.node);
     const parent = getParentElement(this.props.parentSelector);
-    parent.removeChild(this.node);
+    parent && parent.removeChild(this.node);
   };
 
   portalRef = ref => {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -177,9 +177,11 @@ class Modal extends Component {
     if (parent) {
       parent.removeChild(this.node);
     } else {
-      /* eslint-disable-next-line no-console  */
+      // eslint-disable-next-line no-console
       console.warn(
-        "Cannot remove modal from the parent element as it no longer exists in the DOM"
+        'React-Modal: "parentSelector" prop did not returned any DOM ' +
+          "element. Make sure that the parent element is unmounted to " +
+          "avoid any memory leaks."
       );
     }
   };


### PR DESCRIPTION
Fixes #769 

Should we also check before calling removeChild here (In `componentDidUpdate()`? 
```
const { prevParent, nextParent } = snapshot;
if (nextParent !== prevParent) {
  prevParent.removeChild(this.node);
  nextParent.appendChild(this.node);
}
```

I'm fairly new to contributing to open-sourced projects. Please let me know if I made any mistakes. Thank you!

---

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
