### PR TITLE
[feat]a better way to judge React version

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -4,13 +4,14 @@ import PropTypes from "prop-types";
 import ModalPortal from "./ModalPortal";
 import * as ariaAppHider from "../helpers/ariaAppHider";
 import SafeHTMLElement, { canUseDOM } from "../helpers/safeHTMLElement";
+import gteVersion from "../helpers/version";
 
 import { polyfill } from "react-lifecycles-compat";
 
 export const portalClassName = "ReactModalPortal";
 export const bodyOpenClassName = "ReactModal__Body--open";
 
-const isReact16 = ReactDOM.createPortal !== undefined;
+const isReact16 = gteVersion(React.version, "16.0.0");
 
 const getCreatePortal = () =>
   isReact16

--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -1,0 +1,32 @@
+function compare(v1, v2) {
+  if (!v1 || !v2) {
+    if (v1) {
+      return 1;
+    } else if (v2) {
+      return -1;
+    }
+    return 0;
+  }
+
+  v1 = String(v1)
+    .split(".")
+    .map(n => Number(n));
+  v2 = String(v2)
+    .split(".")
+    .map(n => Number(n));
+
+  var len = Math.min(v1.length, v2.length);
+  for (var i = 0; i < len; i++) {
+    if (v1[i] > v2[i]) {
+      return 1;
+    } else if (v1[i] < v2[i]) {
+      return -1;
+    }
+  }
+
+  return v1.length - v2.length;
+}
+
+export default function gteVersion(v1, v2) {
+  return compare(v1, v2) >= 0;
+}


### PR DESCRIPTION
Fixes #[issue number].

Changes proposed:

- it's a better way to judge React version, no longer dependent on the「createPortal」 api

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
