### PR TITLE
[fixed] Focus trap when reentering document (#742)

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -77,6 +77,15 @@ export default class ModalPortal extends Component {
     if (this.props.isOpen) {
       this.open();
     }
+
+    // Body focus trap see Issue #742
+    this.bodyFocusTrapBefore = document.createElement("div");
+    this.bodyFocusTrapBefore.style.position = "absolute";
+    this.bodyFocusTrapBefore.style.opacity = "0";
+    this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
+    this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
+    this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
+    this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -151,6 +160,16 @@ export default class ModalPortal extends Component {
       ariaHiddenInstances += 1;
       ariaAppHider.hide(appElement);
     }
+
+    if (document.body.firstChild !== this.bodyFocusTrapBefore) {
+      document.body.insertBefore(
+        this.bodyFocusTrapBefore,
+        document.body.firstChild
+      );
+    }
+    if (document.body.lastChild !== this.bodyFocusTrapAfter) {
+      document.body.appendChild(this.bodyFocusTrapAfter);
+    }
   }
 
   afterClose = () => {
@@ -190,6 +209,13 @@ export default class ModalPortal extends Component {
 
     if (this.props.onAfterClose) {
       this.props.onAfterClose();
+    }
+
+    if (this.bodyFocusTrapBefore.parentElement === document.body) {
+      document.body.removeChild(this.bodyFocusTrapBefore);
+    }
+    if (this.bodyFocusTrapAfter.parentElement === document.body) {
+      document.body.removeChild(this.bodyFocusTrapAfter);
     }
   };
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -73,13 +73,15 @@ export default class ModalPortal extends Component {
     this.moveFromContentToOverlay = null;
 
     // Body focus trap see Issue #742
-    this.bodyFocusTrapBefore = document.createElement("div");
-    this.bodyFocusTrapBefore.style.position = "absolute";
-    this.bodyFocusTrapBefore.style.opacity = "0";
-    this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
-    this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
-    this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
-    this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
+    if (typeof window !== "undefined") {
+      this.bodyFocusTrapBefore = document.createElement("div");
+      this.bodyFocusTrapBefore.style.position = "absolute";
+      this.bodyFocusTrapBefore.style.opacity = "0";
+      this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
+      this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
+      this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
+      this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
+    }
   }
 
   componentDidMount() {
@@ -161,14 +163,16 @@ export default class ModalPortal extends Component {
       ariaAppHider.hide(appElement);
     }
 
-    if (document.body.firstChild !== this.bodyFocusTrapBefore) {
-      document.body.insertBefore(
-        this.bodyFocusTrapBefore,
-        document.body.firstChild
-      );
-    }
-    if (document.body.lastChild !== this.bodyFocusTrapAfter) {
-      document.body.appendChild(this.bodyFocusTrapAfter);
+    if (typeof window !== "undefined") {
+      if (document.body.firstChild !== this.bodyFocusTrapBefore) {
+        document.body.insertBefore(
+          this.bodyFocusTrapBefore,
+          document.body.firstChild
+        );
+      }
+      if (document.body.lastChild !== this.bodyFocusTrapAfter) {
+        document.body.appendChild(this.bodyFocusTrapAfter);
+      }
     }
   }
 
@@ -211,11 +215,13 @@ export default class ModalPortal extends Component {
       this.props.onAfterClose();
     }
 
-    if (this.bodyFocusTrapBefore.parentElement === document.body) {
-      document.body.removeChild(this.bodyFocusTrapBefore);
-    }
-    if (this.bodyFocusTrapAfter.parentElement === document.body) {
-      document.body.removeChild(this.bodyFocusTrapAfter);
+    if (typeof window !== "undefined") {
+      if (this.bodyFocusTrapBefore.parentElement === document.body) {
+        document.body.removeChild(this.bodyFocusTrapBefore);
+      }
+      if (this.bodyFocusTrapAfter.parentElement === document.body) {
+        document.body.removeChild(this.bodyFocusTrapAfter);
+      }
     }
   };
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -73,15 +73,13 @@ export default class ModalPortal extends Component {
     this.moveFromContentToOverlay = null;
 
     // Body focus trap see Issue #742
-    if (typeof window !== "undefined") {
-      this.bodyFocusTrapBefore = document.createElement("div");
-      this.bodyFocusTrapBefore.style.position = "absolute";
-      this.bodyFocusTrapBefore.style.opacity = "0";
-      this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
-      this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
-      this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
-      this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
-    }
+    this.bodyFocusTrapBefore = document.createElement("div");
+    this.bodyFocusTrapBefore.style.position = "absolute";
+    this.bodyFocusTrapBefore.style.opacity = "0";
+    this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
+    this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
+    this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
+    this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
   }
 
   componentDidMount() {
@@ -163,16 +161,14 @@ export default class ModalPortal extends Component {
       ariaAppHider.hide(appElement);
     }
 
-    if (typeof window !== "undefined") {
-      if (document.body.firstChild !== this.bodyFocusTrapBefore) {
-        document.body.insertBefore(
-          this.bodyFocusTrapBefore,
-          document.body.firstChild
-        );
-      }
-      if (document.body.lastChild !== this.bodyFocusTrapAfter) {
-        document.body.appendChild(this.bodyFocusTrapAfter);
-      }
+    if (document.body.firstChild !== this.bodyFocusTrapBefore) {
+      document.body.insertBefore(
+        this.bodyFocusTrapBefore,
+        document.body.firstChild
+      );
+    }
+    if (document.body.lastChild !== this.bodyFocusTrapAfter) {
+      document.body.appendChild(this.bodyFocusTrapAfter);
     }
   }
 
@@ -215,13 +211,11 @@ export default class ModalPortal extends Component {
       this.props.onAfterClose();
     }
 
-    if (typeof window !== "undefined") {
-      if (this.bodyFocusTrapBefore.parentElement === document.body) {
-        document.body.removeChild(this.bodyFocusTrapBefore);
-      }
-      if (this.bodyFocusTrapAfter.parentElement === document.body) {
-        document.body.removeChild(this.bodyFocusTrapAfter);
-      }
+    if (this.bodyFocusTrapBefore.parentElement === document.body) {
+      document.body.removeChild(this.bodyFocusTrapBefore);
+    }
+    if (this.bodyFocusTrapAfter.parentElement === document.body) {
+      document.body.removeChild(this.bodyFocusTrapAfter);
     }
   };
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -71,12 +71,6 @@ export default class ModalPortal extends Component {
 
     this.shouldClose = null;
     this.moveFromContentToOverlay = null;
-  }
-
-  componentDidMount() {
-    if (this.props.isOpen) {
-      this.open();
-    }
 
     // Body focus trap see Issue #742
     this.bodyFocusTrapBefore = document.createElement("div");
@@ -86,6 +80,12 @@ export default class ModalPortal extends Component {
     this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
     this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
     this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
+  }
+
+  componentDidMount() {
+    if (this.props.isOpen) {
+      this.open();
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -154,7 +154,6 @@ export default class ModalPortal extends Component {
       ariaAppHider.hide(appElement);
     }
 
-    console.log("registering");
     portalOpenInstances.register(this);
   }
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -5,6 +5,8 @@ import scopeTab from "../helpers/scopeTab";
 import * as ariaAppHider from "../helpers/ariaAppHider";
 import * as classList from "../helpers/classList";
 import SafeHTMLElement from "../helpers/safeHTMLElement";
+import portalOpenInstances from "../helpers/portalOpenInstances";
+import "../helpers/bodyTrap";
 
 // so that our CSS is statically analyzable
 const CLASS_NAMES = {
@@ -71,15 +73,6 @@ export default class ModalPortal extends Component {
 
     this.shouldClose = null;
     this.moveFromContentToOverlay = null;
-
-    // Body focus trap see Issue #742
-    this.bodyFocusTrapBefore = document.createElement("div");
-    this.bodyFocusTrapBefore.style.position = "absolute";
-    this.bodyFocusTrapBefore.style.opacity = "0";
-    this.bodyFocusTrapBefore.setAttribute("tabindex", "0");
-    this.bodyFocusTrapAfter = this.bodyFocusTrapBefore.cloneNode();
-    this.bodyFocusTrapBefore.addEventListener("focus", this.focusContent);
-    this.bodyFocusTrapAfter.addEventListener("focus", this.focusContent);
   }
 
   componentDidMount() {
@@ -161,15 +154,8 @@ export default class ModalPortal extends Component {
       ariaAppHider.hide(appElement);
     }
 
-    if (document.body.firstChild !== this.bodyFocusTrapBefore) {
-      document.body.insertBefore(
-        this.bodyFocusTrapBefore,
-        document.body.firstChild
-      );
-    }
-    if (document.body.lastChild !== this.bodyFocusTrapAfter) {
-      document.body.appendChild(this.bodyFocusTrapAfter);
-    }
+    console.log("registering");
+    portalOpenInstances.register(this);
   }
 
   afterClose = () => {
@@ -211,12 +197,7 @@ export default class ModalPortal extends Component {
       this.props.onAfterClose();
     }
 
-    if (this.bodyFocusTrapBefore.parentElement === document.body) {
-      document.body.removeChild(this.bodyFocusTrapBefore);
-    }
-    if (this.bodyFocusTrapAfter.parentElement === document.body) {
-      document.body.removeChild(this.bodyFocusTrapAfter);
-    }
+    portalOpenInstances.deregister(this);
   };
 
   open = () => {

--- a/src/helpers/bodyTrap.js
+++ b/src/helpers/bodyTrap.js
@@ -1,0 +1,47 @@
+import portalOpenInstances from "./portalOpenInstances";
+// Body focus trap see Issue #742
+
+let before, after, instances;
+
+function focusContent() {
+  if (!instances || instances.length === 0) {
+    console.warn(`Open instances > 0 expected`);
+    return;
+  }
+  instances[instances.length - 1].focusContent();
+}
+
+function bodyTrap(eventType, openInstances) {
+  if (!before || !after) {
+    before = document.createElement("div");
+    before.setAttribute("data-react-modal-body-trap", "");
+    before.style.position = "absolute";
+    before.style.opacity = "0";
+    before.setAttribute("tabindex", "0");
+    before.addEventListener("focus", focusContent);
+    after = before.cloneNode();
+    after.addEventListener("focus", focusContent);
+  }
+
+  instances = openInstances;
+
+  if (instances.length > 0) {
+    // Add focus trap
+    if (document.body.firstChild !== before) {
+      document.body.insertBefore(before, document.body.firstChild);
+    }
+    if (document.body.lastChild !== after) {
+      document.body.appendChild(after);
+    }
+  } else {
+    // Remove focus trap
+    if (before.parentElement) {
+      before.parentElement.removeChild(before);
+    }
+    if (after.parentElement) {
+      after.parentElement.removeChild(after);
+    }
+  }
+}
+
+portalOpenInstances.subscribe(bodyTrap);

--- a/src/helpers/bodyTrap.js
+++ b/src/helpers/bodyTrap.js
@@ -5,7 +5,8 @@ let before, after, instances;
 
 function focusContent() {
   if (!instances || instances.length === 0) {
-    console.warn(`Open instances > 0 expected`);
+    // eslint-disable-next-line no-console
+    console.warn(`React-Modal: Open instances > 0 expected`);
     return;
   }
   instances[instances.length - 1].focusContent();

--- a/src/helpers/bodyTrap.js
+++ b/src/helpers/bodyTrap.js
@@ -1,12 +1,16 @@
 import portalOpenInstances from "./portalOpenInstances";
 // Body focus trap see Issue #742
 
-let before, after, instances;
+let before,
+  after,
+  instances = [];
 
 function focusContent() {
-  if (!instances || instances.length === 0) {
-    // eslint-disable-next-line no-console
-    console.warn(`React-Modal: Open instances > 0 expected`);
+  if (instances.length === 0) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(`React-Modal: Open instances > 0 expected`);
+    }
     return;
   }
   instances[instances.length - 1].focusContent();

--- a/src/helpers/portalOpenInstances.js
+++ b/src/helpers/portalOpenInstances.js
@@ -8,10 +8,12 @@ class PortalOpenInstances {
 
   register = openInstance => {
     if (this.openInstances.indexOf(openInstance) !== -1) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `React-Modal: Cannot register modal instance that's already open`
-      );
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `React-Modal: Cannot register modal instance that's already open`
+        );
+      }
       return;
     }
     this.openInstances.push(openInstance);
@@ -21,10 +23,12 @@ class PortalOpenInstances {
   deregister = openInstance => {
     const index = this.openInstances.indexOf(openInstance);
     if (index === -1) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `React-Modal: Unable to deregister ${openInstance} as it was never registered`
-      );
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `React-Modal: Unable to deregister ${openInstance} as it was never registered`
+        );
+      }
       return;
     }
     this.openInstances.splice(index, 1);

--- a/src/helpers/portalOpenInstances.js
+++ b/src/helpers/portalOpenInstances.js
@@ -8,7 +8,10 @@ class PortalOpenInstances {
 
   register = openInstance => {
     if (this.openInstances.indexOf(openInstance) !== -1) {
-      console.warn(`Cannot register modal instance that's already open`);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `React-Modal: Cannot register modal instance that's already open`
+      );
       return;
     }
     this.openInstances.push(openInstance);
@@ -18,8 +21,9 @@ class PortalOpenInstances {
   deregister = openInstance => {
     const index = this.openInstances.indexOf(openInstance);
     if (index === -1) {
+      // eslint-disable-next-line no-console
       console.warn(
-        `Unable to deregister ${openInstance} as it was never registered`
+        `React-Modal: Unable to deregister ${openInstance} as it was never registered`
       );
       return;
     }

--- a/src/helpers/portalOpenInstances.js
+++ b/src/helpers/portalOpenInstances.js
@@ -1,0 +1,47 @@
+// Tracks portals that are open and emits events to subscribers
+
+class PortalOpenInstances {
+  constructor() {
+    this.openInstances = [];
+    this.subscribers = [];
+  }
+
+  register = openInstance => {
+    if (this.openInstances.indexOf(openInstance) !== -1) {
+      console.warn(`Cannot register modal instance that's already open`);
+      return;
+    }
+    this.openInstances.push(openInstance);
+    this.emit("register");
+  };
+
+  deregister = openInstance => {
+    const index = this.openInstances.indexOf(openInstance);
+    if (index === -1) {
+      console.warn(
+        `Unable to deregister ${openInstance} as it was never registered`
+      );
+      return;
+    }
+    this.openInstances.splice(index, 1);
+    this.emit("deregister");
+  };
+
+  subscribe = callback => {
+    this.subscribers.push(callback);
+  };
+
+  emit = eventType => {
+    this.subscribers.forEach(subscriber =>
+      subscriber(
+        eventType,
+        // shallow copy to avoid accidental mutation
+        this.openInstances.slice()
+      )
+    );
+  };
+}
+
+const portalOpenInstances = new PortalOpenInstances();
+
+export default portalOpenInstances;


### PR DESCRIPTION
Fixes #742

Changes proposed:
- Ensure modal focus trap when reentering document. This restores modal focus when navigating into the page by keyboard. See discussion on #742 and #787

Upgrade Path (for changed or removed APIs):
- N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- ~[ ] Documentation (README.md) and examples have been updated as needed.~ *N/A I think*
- [ ] If this is a code change, a spec testing the functionality has been added.
- ~[ ] If the commit message has [changed] or [removed], there is an upgrade path above.~ *N/A I think*
