### PR TITLE
[fixed] set correct URL for codepen setAppElement example

### DIFF
--- a/docs/examples/set_app_element.md
+++ b/docs/examples/set_app_element.md
@@ -4,4 +4,4 @@ This example shows how to use setAppElement to properly hide your application fr
 
 You'll notice in this example that the aria-hidden attribute is applied to the #main div rather than the document body.
 
-[setAppElement example](codepen://claydiffrient/ENegGJ)
+[setAppElement example](https://codepen.io/claydiffrient/pen/ENegGJ)


### PR DESCRIPTION
Changes proposed:

The docs has an invalid URL, and this commit sets the correct link.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`
- [x] Documentation (README.md) and examples have been updated as needed.