### PR TITLE
[fixed] - Fix broken links of codepen in examples in docs

### DIFF
--- a/docs/examples/css_classes.md
+++ b/docs/examples/css_classes.md
@@ -4,4 +4,4 @@ If you prefer to use CSS to handle styling the modal you can.
 
 One thing to note is that by using the className property you will override all default styles.
 
-[CSS classes example](codepen://claydiffrient/KNjVrG)
+[CSS classes example](https://codepen.io/claydiffrient/pen/KNjVrG)

--- a/docs/examples/global_overrides.md
+++ b/docs/examples/global_overrides.md
@@ -2,4 +2,4 @@
 
 If you'll be using several modals and want to adjust styling for all of them in one location you can by modifying `Modal.defaultStyles`.
 
-[Global overrides example](codepen://claydiffrient/pNXgqQ)
+[Global overrides example](https://codepen.io/claydiffrient/pen/pNXgqQ)

--- a/docs/examples/inline_styles.md
+++ b/docs/examples/inline_styles.md
@@ -2,4 +2,4 @@
 
 This example shows how to use inline styles to adjust the modal.
 
-[inline styles example](codepen://claydiffrient/ZBmyKz)
+[inline styles example](https://codepen.io/claydiffrient/pen/ZBmyKz)

--- a/docs/examples/minimal.md
+++ b/docs/examples/minimal.md
@@ -2,4 +2,4 @@
 
 This example shows the minimal needed to get React Modal to work.
 
-[Minimal example](codepen://claydiffrient/KNxgav)
+[Minimal example](https://codepen.io/claydiffrient/pen/KNxgav)

--- a/docs/examples/on_request_close.md
+++ b/docs/examples/on_request_close.md
@@ -6,5 +6,4 @@ This is especially important for handling closing the modal via the escape key.
 
 Also more important if `shouldCloseOnOverlayClick` is set to `true`, when clicked on overlay it calls `onRequestClose`.
 
-
-[onRequestClose example](codepen://claydiffrient/KNjVBx)
+[onRequestClose example](https://codepen.io/claydiffrient/pen/KNjVBx)

--- a/docs/examples/should_close_on_overlay_click.md
+++ b/docs/examples/should_close_on_overlay_click.md
@@ -5,6 +5,6 @@ it requires the `onRequestClose` to be defined in order to close the <Modal/>.
 This is due to the fact that the `react-modal` doesn't store the `isOpen`
 on its state (only for the internal `portal` (see [ModalPortal.js](https://github.com/reactjs/react-modal/blob/master/src/components/ModalPortal.js)).
 
-[disable 'close on overlay click', codepen by claydiffrient](codepen://claydiffrient/woLzwo)
+[disable 'close on overlay click', codepen by claydiffrient](https://codepen.io/claydiffrient/pen/woLzwo)
 
-[enable 'close on overlay click', codepen by sbgriffi](codepen://sbgriffi/WMyBaR)
+[enable 'close on overlay click', codepen by sbgriffi](https://codepen.io/sbgriffi/pen/WMyBaR)


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>


Changes proposed:

This commit will fix broken codepen urls in examples files of docs. Those md
files are following
- css_classes.md
- global_overrides.md
- inline_styles.md
- minimal.md
- on_request_close.md
- should_close_on_overlay_click.md

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
