### PR TITLE
[fixed] - Ensure focus does not scroll the modal

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -233,7 +233,7 @@ export default class ModalPortal extends Component {
 
   // Don't steal focus from inner elements
   focusContent = () =>
-    this.content && !this.contentHasFocus() && this.content.focus();
+    this.content && !this.contentHasFocus() && this.content.focus({ preventScroll: true });
 
   closeWithTimeout = () => {
     const closesAt = Date.now() + this.props.closeTimeoutMS;

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -233,7 +233,9 @@ export default class ModalPortal extends Component {
 
   // Don't steal focus from inner elements
   focusContent = () =>
-    this.content && !this.contentHasFocus() && this.content.focus({ preventScroll: true });
+    this.content &&
+    !this.contentHasFocus() &&
+    this.content.focus({ preventScroll: true });
 
   closeWithTimeout = () => {
     const closesAt = Date.now() + this.props.closeTimeoutMS;


### PR DESCRIPTION
In IOS we found that the focus of an element would scroll the page so such element is brought into view.

In our case we have a grid of several views (iframes) and whenever a modal would appear on one of those views then the whole app would scroll to show the cell were the modal appeared, which is undesireable.

This PR fixes that.
