### PR TITLE
[fixed] lazily access ReactDOM.createPortal

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,7 +10,7 @@ import { polyfill } from "react-lifecycles-compat";
 export const portalClassName = "ReactModalPortal";
 export const bodyOpenClassName = "ReactModal__Body--open";
 
-const isReact16 = ReactDOM.createPortal !== undefined;
+const isReact16 = canUseDOM && ReactDOM.createPortal !== undefined;
 
 const getCreatePortal = () =>
   isReact16


### PR DESCRIPTION
Fixes #824

Changes proposed:

- Access `ReactDOM.createPortal` via a function instead of directly, so it is only accessed when required, not when the script is compiled. Stops errors being thrown when bundled into script that is run in an environment without access to ReactDOM.

Upgrade Path (for changed or removed APIs):

N/A

Acceptance Checklist:
- [X] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] (N/A) Documentation (README.md) and examples have been updated as needed.
- [ ] (N/A) If this is a code change, a spec testing the functionality has been added.
- [ ] (N/A) If the commit message has [changed] or [removed], there is an upgrade path above.
