### PR TITLE
[fixed] extra 'p' character in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,7 +180,6 @@ choose a different parent element by providing a function to the
   <p>Modal Content.</p>
 </Modal>
 ```
-p
 If you do this, please ensure that your
 [app element](accessibility/README.md#app-element) is set correctly.  The app
 element should not be a parent of the modal, to prevent modal content from


### PR DESCRIPTION
Fixes #830 by removing what I think is a typo: the character 'p' at the beginning of the "Using a custom parent node" on react-modal's documentation page.

Changes proposed:

- Updating [`index.md`](https://github.com/reactjs/react-modal/blob/master/docs/index.md) to remove what I think is a typo.

Upgrade Path (for changed or removed APIs):
I don't think this is applicable.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
