### PR TITLE
[fixed] stale link in react-modal/docs/styles/classes.md

### DIFF
--- a/docs/styles/classes.md
+++ b/docs/styles/classes.md
@@ -24,7 +24,7 @@ will be closed immediately when requested.  Thus, if you are using the
 set `closeTimeoutMS` to the length (in milliseconds) of your closing
 transition.
 
-If you specify `className`, the [default content styles](README.md) will not be
+If you specify `className`, the [default content styles](index.md) will not be
 applied.  Likewise, if you specify `overlayClassName`, the default overlay
 styles will not be applied.
 


### PR DESCRIPTION
All this does is change the "default content styles" hyperlink to `index.md` instead of `README.md`, since I think the link to `README.md` is stale since at least [Dec 9, 2019](https://github.com/reactjs/react-modal/tree/e5fe406111f97269b8a552e9fc5ee285e05941fa/docs/styles) with commit e5fe406111f97269b8a552e9fc5ee285e05941fa.

Fixes #833.

Changes proposed:

- Update "default content styles" hyperlink in [`classes.md`](https://github.com/reactjs/react-modal/blob/master/docs/styles/classes.md) to link to `index.md` instead of `README.md`

Upgrade Path (for changed or removed APIs):
I don't think this is applicable for this pull request.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.