### PR TITLE
[fixed] add aria-modal attribute

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -379,7 +379,7 @@ export default class ModalPortal extends Component {
       onClick: this.handleContentOnClick,
       role: this.props.role,
       "aria-label": this.props.contentLabel,
-      ...this.attributesFromObject("aria", this.props.aria || {}),
+      ...this.attributesFromObject("aria", { modal: true, ...this.props.aria }),
       ...this.attributesFromObject("data", this.props.data || {}),
       "data-testid": this.props.testId
     };


### PR DESCRIPTION
As it said in the [comment](https://github.com/reactjs/react-modal/issues/654#issuecomment-672640981) of #654 Safari has no longer problem with aria-modal='true'

Without aria-modal, React Testing library seems have some troubles to find de modal role.

Now, with the current version of the code of React-modal and Safari, the modal seems to be able to be reintroduce.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed. => No Needed
- [x] If this is a code change, a spec testing the functionality has been added. => No Needed
- [x] If the commit message has [changed] or [removed], there is an upgrade path above. => No Needed
