### PR TITLE
bump prop-types to 15.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,9 +1046,9 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "exenv": "^1.2.0",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.7.2",
     "react-lifecycles-compat": "^3.0.0",
     "warning": "^4.0.3"
   },


### PR DESCRIPTION
Changes proposed:

- upgrade prop-types dependency to 15.7.2 
- this upgrade remediates a high risk vulnerability identified in transitive dependency ua-parser-js
- see: [https://snyk.io/test/npm/ua-parser-js/0.7.21](https://snyk.io/test/npm/ua-parser-js/0.7.21?tab=issues )

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
