### PR TITLE
[fixed] Cancel requested animation frame on unmount.

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -131,6 +131,7 @@ export default class ModalPortal extends Component {
       this.afterClose();
     }
     clearTimeout(this.closeTimer);
+    cancelAnimationFrame(this.openAnimationFrame);
   }
 
   setOverlayRef = overlay => {
@@ -222,7 +223,7 @@ export default class ModalPortal extends Component {
       }
 
       this.setState({ isOpen: true }, () => {
-        requestAnimationFrame(() => {
+        this.openAnimationFrame = requestAnimationFrame(() => {
           this.setState({ afterOpen: true });
 
           if (this.props.isOpen && this.props.onAfterOpen) {


### PR DESCRIPTION
Fixes #882 .

Changes proposed:

- Be sure to cancel the animation frame that is requested in the ModalPortal open method so that a state change is not potentially requested after the component is unmounted.

In the issue description I mentioned that `isMounted` might be a potential fix, but then I [read that it is an antipattern](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html). The `componentWillUnmount` method is already clearing a timeout, so canceling the animation seems like the best option.

I can confirm that these changes fix the error message I was seeing in the jest/testing-library environment I am using in a separate project. It is unclear to me how to reproduce this race condition in the testing setup used in this project. Any ideas would be appreciated.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
