### PR TITLE
[added] update README regarding onAfterOpen and Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NOTE
 
-Need feedback to push a new version of `react-modal` forward. See issue [#881](https://github.com/reactjs/react-modal/issues/881). 
+Need feedback to push a new version of `react-modal` forward. See issue [#881](https://github.com/reactjs/react-modal/issues/881).
 
 
 Accessible modal dialog component for React.JS
@@ -118,3 +118,7 @@ demonstrate various features of react-modal:
 * [Using inline styles](https://codepen.io/claydiffrient/pen/ZBmyKz)
 * [Using CSS classes for styling](https://codepen.io/claydiffrient/pen/KNjVrG)
 * [Customizing the default styles](https://codepen.io/claydiffrient/pen/pNXgqQ)
+
+## Testing `onAfterOpen` and Jest
+
+The `onAfterOpen` prop calls `requestAnimationFrame` which can break Jest tests that were written prior to [v3.14.1](https://github.com/reactjs/react-modal/releases/tag/v3.14.1). Please review the [Jest bug](https://github.com/facebook/jest/issues/5147) for details on how to resolve these test failures, as well as how to support new tests related to `onAfterOpen`.


### PR DESCRIPTION
Changes proposed:

- Providing an additional section in the README related to the post v3.14.1 change to the behavior of the `onAfterOpen` prop and how it can break Jest tests related to it.

I am not sure if this is the best way to communicate this change, but I can speak from experience that this was an unexpectedly disruptive one in my organization, and hopefully this can spare others the time it took me to discover the source of a number of failing tests when I made the minor update.


Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
