### PR TITLE
[fixed] Ensure we don't check for hidden on Shadow DOM.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,6 +1386,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webcomponents/custom-elements": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.5.0.tgz",
+      "integrity": "sha512-c+7jPQCs9h/BYVcZ2Kna/3tsl3A/9EyXfvWjp5RiTDm1OpTcbZaCa1z4RNcTe/hUtXaqn64JjNW1yrWT+rZ8gg==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@webcomponents/custom-elements": "^1.5.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.1",

--- a/specs/Modal.helpers.spec.js
+++ b/specs/Modal.helpers.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import "should";
+import "@webcomponents/custom-elements/src/native-shim";
 import tabbable from "../src/helpers/tabbable";
 import "sinon";
 
@@ -113,6 +114,60 @@ export default () => {
         button.style.overflow = "visible";
         elem.appendChild(button);
         tabbable(elem).should.not.containEql(button);
+      });
+
+      describe("inside Web Components", () => {
+        let wc;
+        let input;
+        class TestWebComponent extends HTMLElement {
+          constructor() {
+            super();
+          }
+
+          connectedCallback() {
+            this.attachShadow({
+              mode: "open"
+            });
+            this.style.display = "block";
+            this.style.width = "100px";
+            this.style.height = "25px";
+          }
+        }
+
+        const registerTestComponent = () => {
+          if (window.customElements.get("test-web-component")) {
+            return;
+          }
+          window.customElements.define("test-web-component", TestWebComponent);
+        };
+
+        beforeEach(() => {
+          registerTestComponent();
+          wc = document.createElement("test-web-component");
+
+          input = document.createElement("input");
+          elem.appendChild(input);
+
+          document.body.appendChild(wc);
+          wc.shadowRoot.appendChild(elem);
+        });
+
+        afterEach(() => {
+          // re-add elem to body for the next afterEach
+          document.body.appendChild(elem);
+
+          // remove Web Component
+          document.body.removeChild(wc);
+        });
+
+        it("includes elements when inside a Shadow DOM", () => {
+          tabbable(elem).should.containEql(input);
+        });
+
+        it("excludes elements when hidden inside a Shadow DOM", () => {
+          wc.style.display = "none";
+          tabbable(elem).should.not.containEql(input);
+        });
       });
     });
   });

--- a/src/helpers/scopeTab.js
+++ b/src/helpers/scopeTab.js
@@ -1,5 +1,11 @@
 import findTabbable from "./tabbable";
 
+function getActiveElement(el = document) {
+  return el.activeElement.shadowRoot
+    ? getActiveElement(el.activeElement.shadowRoot)
+    : el.activeElement;
+}
+
 export default function scopeTab(node, event) {
   const tabbable = findTabbable(node);
 
@@ -14,19 +20,20 @@ export default function scopeTab(node, event) {
   const shiftKey = event.shiftKey;
   const head = tabbable[0];
   const tail = tabbable[tabbable.length - 1];
+  const activeElement = getActiveElement();
 
   // proceed with default browser behavior on tab.
   // Focus on last element on shift + tab.
-  if (node === document.activeElement) {
+  if (node === activeElement) {
     if (!shiftKey) return;
     target = tail;
   }
 
-  if (tail === document.activeElement && !shiftKey) {
+  if (tail === activeElement && !shiftKey) {
     target = head;
   }
 
-  if (head === document.activeElement && shiftKey) {
+  if (head === activeElement && shiftKey) {
     target = tail;
   }
 
@@ -57,7 +64,7 @@ export default function scopeTab(node, event) {
   // the focus
   if (!isSafariDesktop) return;
 
-  var x = tabbable.indexOf(document.activeElement);
+  var x = tabbable.indexOf(activeElement);
 
   if (x > -1) {
     x += shiftKey ? -1 : 1;

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -35,10 +35,7 @@ function hidesContents(element) {
 
 function visible(element) {
   let parentElement = element;
-  let rootNode =
-    typeof element.getRootNode === "function"
-      ? element.getRootNode()
-      : undefined;
+  let rootNode = element.getRootNode && element.getRootNode();
   while (parentElement) {
     if (parentElement === document.body) break;
     if (rootNode && parentElement === rootNode) parentElement = rootNode.host;

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -68,10 +68,9 @@ export default function findTabbableDescendants(element) {
   const descendants = [].slice
     .call(element.querySelectorAll("*"), 0)
     .reduce(
-      (finished, el) => [
-        ...finished,
-        ...(!el.shadowRoot ? [el] : findTabbableDescendants(el.shadowRoot))
-      ],
+      (finished, el) => finished.concat(
+        !el.shadowRoot ? [el] : findTabbableDescendants(el.shadowRoot)
+      ),
       []
     );
   return descendants.filter(tabbable);

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -35,8 +35,13 @@ function hidesContents(element) {
 
 function visible(element) {
   let parentElement = element;
+  let rootNode =
+    typeof element.getRootNode === "function"
+      ? element.getRootNode()
+      : undefined;
   while (parentElement) {
     if (parentElement === document.body) break;
+    if (rootNode && parentElement === rootNode) parentElement = rootNode.host;
     if (hidesContents(parentElement)) return false;
     parentElement = parentElement.parentNode;
   }

--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -38,7 +38,11 @@ function visible(element) {
   let rootNode = element.getRootNode && element.getRootNode();
   while (parentElement) {
     if (parentElement === document.body) break;
-    if (rootNode && parentElement === rootNode) parentElement = rootNode.host;
+
+    // if we are not hidden yet, skip to checking outside the Web Component
+    if (rootNode && parentElement === rootNode)
+      parentElement = rootNode.host.parentNode;
+
     if (hidesContents(parentElement)) return false;
     parentElement = parentElement.parentNode;
   }
@@ -61,5 +65,14 @@ function tabbable(element) {
 }
 
 export default function findTabbableDescendants(element) {
-  return [].slice.call(element.querySelectorAll("*"), 0).filter(tabbable);
+  const descendants = [].slice
+    .call(element.querySelectorAll("*"), 0)
+    .reduce(
+      (finished, el) => [
+        ...finished,
+        ...(!el.shadowRoot ? [el] : findTabbableDescendants(el.shadowRoot))
+      ],
+      []
+    );
+  return descendants.filter(tabbable);
 }


### PR DESCRIPTION
When inside a Shadow DOM, the loop will eventually reach the Shadow DOM element itself, which cannot be checked for visibility. We can continue our upwards check by skipping to the Shadow DOM host.

Changes proposed:

- Skip the Shadow DOM element (`rootNode` when inside a Shadow DOM) when checking for visibility.
- Ensure that we know about every tabbable element, even those within Shadow DOM.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
