### PR TITLE
[added] Overlay right click is handled like a regular click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal",
-  "version": "3.14.3",
+  "version": "3.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal",
-  "version": "3.14.2",
+  "version": "3.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -8,6 +8,7 @@ import {
   moverlay,
   mcontent,
   clickAt,
+  rightClickAt,
   mouseDownAt,
   mouseUpAt,
   escKeyDown,
@@ -70,7 +71,7 @@ export default () => {
 
   it("keeps focus inside the modal when child has no tabbable elements", () => {
     let tabPrevented = false;
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, "hello", modal => {
       const content = mcontent(modal);
       document.activeElement.should.be.eql(content);
@@ -84,7 +85,7 @@ export default () => {
   });
 
   it("handles case when child has no tabbable elements", () => {
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, "hello", modal => {
       const content = mcontent(modal);
       tabKeyDown(content);
@@ -101,7 +102,7 @@ export default () => {
         {bottomButton}
       </div>
     );
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, modalContent, modal => {
       const content = mcontent(modal);
       tabKeyDown(content, { shiftKey: true });
@@ -170,6 +171,19 @@ export default () => {
       };
       withModal(props, null, modal => {
         clickAt(moverlay(modal));
+        requestCloseCallback.called.should.be.ok();
+      });
+    });
+
+    it("when true, right click on overlay must close", () => {
+      const requestCloseCallback = sinon.spy();
+      const props = {
+        isOpen: true,
+        shouldCloseOnOverlayClick: true,
+        onRequestClose: requestCloseCallback
+      };
+      withModal(props, null, modal => {
+        rightClickAt(moverlay(modal));
         requestCloseCallback.called.should.be.ok();
       });
     });

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -204,6 +204,10 @@ export const tabKeyDown = dispatchMockKeyDownEvent("TAB", 9);
  */
 export const clickAt = Simulate.click;
 /**
+ * Dispatch a 'context menu' (right click) event at a node.
+ */
+export const rightClickAt = Simulate.contextMenu;
+/**
  * Dispatch a 'mouse up' event at a node.
  */
 export const mouseUpAt = Simulate.mouseUp;

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -375,6 +375,7 @@ export default class ModalPortal extends Component {
       className: this.buildClassName("overlay", overlayClassName),
       style: { ...overlayStyles, ...this.props.style.overlay },
       onClick: this.handleOverlayOnClick,
+      onContextMenu: this.handleOverlayOnClick,
       onMouseDown: this.handleOverlayOnMouseDown
     };
 


### PR DESCRIPTION
Fixes #837.

Changes proposed:
Added handling of right clicks on the modal's overlay, so it uses the exact same functionality of the regular overlay click.

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
