### PR TITLE
[added] tabbable support for iframes

### DIFF
--- a/src/helpers/tabbable.js
+++ b/src/helpers/tabbable.js
@@ -10,7 +10,7 @@
  * http://api.jqueryui.com/category/ui-core/
  */
 
-const tabbableNode = /input|select|textarea|button|object/;
+const tabbableNode = /input|select|textarea|button|object|iframe/;
 
 function hidesContents(element) {
   const zeroSize = element.offsetWidth <= 0 && element.offsetHeight <= 0;


### PR DESCRIPTION
Iframes are, just like a button, anchor or inputs, an interactive element that should be focusable in modal. For example I play youtube videos in modals. Keyboard users should be able to pause video (or trigger any other action) as well.

Changes proposed:

- add `iframe` to list of tabbable elements

Upgrade Path (for changed or removed APIs):
N/A

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
