### PR TITLE
[fixed] stacked/nested modals have focus lost in Safari

### DIFF
--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -109,6 +109,30 @@ export default () => {
     });
   });
 
+  it("shifts focus within nested modals", () => {
+    withElementCollector(() => {
+      let nestedModal;
+      const props = { isOpen: true };
+      const node = createHTMLElement("div");
+
+      ReactDOM.render(
+        <Modal {...props} appElement={node}>
+          <button>Outer Button 1</button>
+          <button>Outer Button 2</button>
+          <Modal ref={el => (nestedModal = el)} appElement={node} a isOpen>
+            <button id="foo">Button One</button>
+            <button id="bar">Button Two</button>
+          </Modal>
+        </Modal>,
+        node
+      );
+      const content = mcontent(nestedModal);
+      tabKeyDown(content, { shiftKey: true });
+      document.activeElement.textContent.should.be.eql("Button Two");
+      ReactDOM.unmountComponentAtNode(node);
+    });
+  });
+
   describe("shouldCloseOnEsc", () => {
     context("when true", () => {
       it("should close on Esc key event", () => {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -275,6 +275,7 @@ export default class ModalPortal extends Component {
 
   handleKeyDown = event => {
     if (event.keyCode === TAB_KEY) {
+      event.stopPropagation();
       scopeTab(this.content, event);
     }
 


### PR DESCRIPTION
If the `keydown` event within the currently-open, nested modal is propagated, Safari will toggle focus between the parent modal's focusable elements instead.

Fixes #801.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
