### PR TITLE
[fixed] switched from KeyboardEvent.keyCode to KeyboardEvent.code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal",
-  "version": "3.14.4",
+  "version": "3.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1564,7 +1564,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
       "dev": true
     },
     "array-includes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal",
-  "version": "3.15.1",
+  "version": "3.14.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1564,7 +1564,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -11,7 +11,9 @@ import {
   mouseDownAt,
   mouseUpAt,
   escKeyDown,
+  escKeyDownWithCode,
   tabKeyDown,
+  tabKeyDownWithCode,
   withModal,
   withElementCollector,
   createHTMLElement
@@ -109,6 +111,23 @@ export default () => {
     });
   });
 
+  it("traps tab in the modal on shift + tab with KeyboardEvent.code", () => {
+    const topButton = <button>top</button>;
+    const bottomButton = <button>bottom</button>;
+    const modalContent = (
+      <div>
+        {topButton}
+        {bottomButton}
+      </div>
+    );
+    const props = { isOpen: true };
+    withModal(props, modalContent, modal => {
+      const content = mcontent(modal);
+      tabKeyDownWithCode(content, { shiftKey: true });
+      document.activeElement.textContent.should.be.eql("bottom");
+    });
+  });
+
   describe("shouldCloseOnEsc", () => {
     context("when true", () => {
       it("should close on Esc key event", () => {
@@ -122,6 +141,25 @@ export default () => {
           null,
           modal => {
             escKeyDown(mcontent(modal));
+            requestCloseCallback.called.should.be.ok();
+            // Check if event is passed to onRequestClose callback.
+            const event = requestCloseCallback.getCall(0).args[0];
+            event.should.be.ok();
+          }
+        );
+      });
+
+      it("should close on Esc key event with KeyboardEvent.code", () => {
+        const requestCloseCallback = sinon.spy();
+        withModal(
+          {
+            isOpen: true,
+            shouldCloseOnEsc: true,
+            onRequestClose: requestCloseCallback
+          },
+          null,
+          modal => {
+            escKeyDownWithCode(mcontent(modal));
             requestCloseCallback.called.should.be.ok();
             // Check if event is passed to onRequestClose callback.
             const event = requestCloseCallback.getCall(0).args[0];

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -182,7 +182,7 @@ const dispatchMockEvent = eventCtor => (key, code) => (element, opts) =>
       {},
       {
         key: key,
-        code: code,
+        keyCode: code,
         which: code
       },
       opts
@@ -194,11 +194,11 @@ const dispatchMockKeyDownEvent = dispatchMockEvent(Simulate.keyDown);
 /**
  * Dispatch an 'esc' key down event from an element.
  */
-export const escKeyDown = dispatchMockKeyDownEvent("ESC", "Escape");
+export const escKeyDown = dispatchMockKeyDownEvent("ESC", 27);
 /**
  * Dispatch a 'tab' key down event from an element.
  */
-export const tabKeyDown = dispatchMockKeyDownEvent("TAB", "Tab");
+export const tabKeyDown = dispatchMockKeyDownEvent("TAB", 9);
 /**
  * Dispatch a 'click' event at a node.
  */

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -182,9 +182,9 @@ const dispatchMockEvent = eventCtor => (key, code) => (element, opts) =>
       {},
       {
         key: key,
-        keyCode: code,
         which: code
       },
+      code,
       opts
     )
   );
@@ -192,13 +192,31 @@ const dispatchMockEvent = eventCtor => (key, code) => (element, opts) =>
 const dispatchMockKeyDownEvent = dispatchMockEvent(Simulate.keyDown);
 
 /**
- * Dispatch an 'esc' key down event from an element.
+ * @deprecated will be replaced by `escKeyDownWithCode` when `react-modal`
+ * drops support for React <18.
+ *
+ * Dispatch an 'esc' key down event using the legacy KeyboardEvent.keyCode.
  */
-export const escKeyDown = dispatchMockKeyDownEvent("ESC", 27);
+export const escKeyDown = dispatchMockKeyDownEvent("ESC", { keyCode: 27 });
 /**
- * Dispatch a 'tab' key down event from an element.
+ * Dispatch an 'esc' key down event.
  */
-export const tabKeyDown = dispatchMockKeyDownEvent("TAB", 9);
+export const escKeyDownWithCode = dispatchMockKeyDownEvent("ESC", {
+  code: "Escape"
+});
+/**
+ * @deprecated will be replaced by `escKeyDownWithCode` when `react-modal`
+ * drops support for React <18.
+ *
+ * Dispatch a 'tab' key down event using the legacy KeyboardEvent.keyCode.
+ */
+export const tabKeyDown = dispatchMockKeyDownEvent("TAB", { keyCode: 9 });
+/**
+ * Dispatch a 'tab' key down event.
+ */
+export const tabKeyDownWithCode = dispatchMockKeyDownEvent("TAB", {
+  code: "Tab"
+});
 /**
  * Dispatch a 'click' event at a node.
  */

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -182,7 +182,7 @@ const dispatchMockEvent = eventCtor => (key, code) => (element, opts) =>
       {},
       {
         key: key,
-        keyCode: code,
+        code: code,
         which: code
       },
       opts
@@ -194,11 +194,11 @@ const dispatchMockKeyDownEvent = dispatchMockEvent(Simulate.keyDown);
 /**
  * Dispatch an 'esc' key down event from an element.
  */
-export const escKeyDown = dispatchMockKeyDownEvent("ESC", 27);
+export const escKeyDown = dispatchMockKeyDownEvent("ESC", "Escape");
 /**
  * Dispatch a 'tab' key down event from an element.
  */
-export const tabKeyDown = dispatchMockKeyDownEvent("TAB", 9);
+export const tabKeyDown = dispatchMockKeyDownEvent("TAB", "Tab");
 /**
  * Dispatch a 'click' event at a node.
  */

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -17,6 +17,18 @@ const CLASS_NAMES = {
   content: "ReactModal__Content"
 };
 
+/**
+ * We need to support the deprecated `KeyboardEvent.keyCode` in addition to
+ * `KeyboardEvent.code` for apps that still support IE11. Can be removed when
+ * `react-modal` only supports React >18 (which dropped IE support).
+ */
+const isTabKey = event => {
+  event.code === "Tab" || event.keyCode === 9;
+};
+const isEscKey = event => {
+  event.code === "Escape" || event.keyCode === 27;
+};
+
 let ariaHiddenInstances = 0;
 
 export default class ModalPortal extends Component {
@@ -271,11 +283,11 @@ export default class ModalPortal extends Component {
   };
 
   handleKeyDown = event => {
-    if (event.code === "Tab") {
+    if (isTabKey(event)) {
       scopeTab(this.content, event);
     }
 
-    if (this.props.shouldCloseOnEsc && event.code === "Escape") {
+    if (this.props.shouldCloseOnEsc && isEscKey(event)) {
       event.stopPropagation();
       this.requestClose(event);
     }

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -22,12 +22,8 @@ const CLASS_NAMES = {
  * `KeyboardEvent.code` for apps that still support IE11. Can be removed when
  * `react-modal` only supports React >18 (which dropped IE support).
  */
-const isTabKey = event => {
-  event.code === "Tab" || event.keyCode === 9;
-};
-const isEscKey = event => {
-  event.code === "Escape" || event.keyCode === 27;
-};
+const isTabKey = event => event.code === "Tab" || event.keyCode === 9;
+const isEscKey = event => event.code === "Escape" || event.keyCode === 27;
 
 let ariaHiddenInstances = 0;
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -17,9 +17,6 @@ const CLASS_NAMES = {
   content: "ReactModal__Content"
 };
 
-const TAB_KEY = 9;
-const ESC_KEY = 27;
-
 let ariaHiddenInstances = 0;
 
 export default class ModalPortal extends Component {
@@ -274,11 +271,11 @@ export default class ModalPortal extends Component {
   };
 
   handleKeyDown = event => {
-    if (event.keyCode === TAB_KEY) {
+    if (event.code === "Tab") {
       scopeTab(this.content, event);
     }
 
-    if (this.props.shouldCloseOnEsc && event.keyCode === ESC_KEY) {
+    if (this.props.shouldCloseOnEsc && event.code === "Escape") {
       event.stopPropagation();
       this.requestClose(event);
     }


### PR DESCRIPTION
Fixes #952.

Changes proposed:

- Switch keydown event listeners to use `KeyboardEvent.code`. The legacy `KeyboardEvent.keyCode` is deprecated. Since React 18 dropped support for IE, we don't need to fall back on it, and can simply switch to the new property
- More context: see #952 

Acceptance Checklist:

- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- ~Documentation (README.md) and examples have been updated as needed.~
- ~If this is a code change, a spec testing the functionality has been added.~
- ~If the commit message has [changed] or [removed], there is an upgrade path above.~
