### PR TITLE
[fixed]: css class added to root document instead of modal ownerDocument

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ import ReactModal from 'react-modal';
 
   bodyOpenClassName={
     "ReactModal__Body--open"
-  /* String className to be applied to the document.body
+  /* String className to be applied to the modal ownerDocument.body
      (must be a constant string).
      This attribute when set as `null` doesn't add any class
      to document.body.
@@ -98,7 +98,7 @@ import ReactModal from 'react-modal';
 
   htmlOpenClassName={
     "ReactModal__Html--open"
-  /* String className to be applied to the document.html
+  /* String className to be applied to the modal ownerDocument.html
      (must be a constant string).
      This attribute is `null` by default.
      See the `Styles` section for more details. */}

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -43,6 +43,7 @@ export default class ModalPortal extends Component {
     }),
     className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     overlayClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    parentSelector: PropTypes.func,
     bodyOpenClassName: PropTypes.string,
     htmlOpenClassName: PropTypes.string,
     ariaHideApp: PropTypes.bool,
@@ -149,15 +150,19 @@ export default class ModalPortal extends Component {
       appElement,
       ariaHideApp,
       htmlOpenClassName,
-      bodyOpenClassName
+      bodyOpenClassName,
+      parentSelector
     } = this.props;
 
+    const parentDocument =
+      (parentSelector && parentSelector().ownerDocument) || document;
+
     // Add classes.
-    bodyOpenClassName && classList.add(document.body, bodyOpenClassName);
+    bodyOpenClassName && classList.add(parentDocument.body, bodyOpenClassName);
 
     htmlOpenClassName &&
       classList.add(
-        document.getElementsByTagName("html")[0],
+        parentDocument.getElementsByTagName("html")[0],
         htmlOpenClassName
       );
 
@@ -174,15 +179,20 @@ export default class ModalPortal extends Component {
       appElement,
       ariaHideApp,
       htmlOpenClassName,
-      bodyOpenClassName
+      bodyOpenClassName,
+      parentSelector
     } = this.props;
 
+    const parentDocument =
+      (parentSelector && parentSelector().ownerDocument) || document;
+
     // Remove classes.
-    bodyOpenClassName && classList.remove(document.body, bodyOpenClassName);
+    bodyOpenClassName &&
+      classList.remove(parentDocument.body, bodyOpenClassName);
 
     htmlOpenClassName &&
       classList.remove(
-        document.getElementsByTagName("html")[0],
+        parentDocument.getElementsByTagName("html")[0],
         htmlOpenClassName
       );
 


### PR DESCRIPTION
Fixes [#[964]](https://github.com/reactjs/react-modal/issues/964)
I am trying to open the modal inside an iframe, but the `bodyOpenClassName` would be applied to the rootDocument instead.
I would like to use the parentSelector to determine where the `bodyOpenClassName` should be added instead of just using `document.body`

Changes proposed:

- `htmlOpenClassName` add to the modal ownerDocument html instead
- `bodyOpenClassName` add to the modal ownerDocument body instead
- Update doc 

Upgrade Path (for changed or removed APIs):


Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.