### PR TITLE
Fixed/988 - Make setAppElement or appElement required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^4.0.3"
+        "react-lifecycles-compat": "^3.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -8759,6 +8758,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -15872,6 +15872,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
   "dependencies": {
     "exenv": "^1.2.0",
     "prop-types": "^15.7.2",
-    "react-lifecycles-compat": "^3.0.0",
-    "warning": "^4.0.3"
+    "react-lifecycles-compat": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15 || ^16 || ^17 || ^18",

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -20,6 +20,20 @@ import {
 } from "./helper";
 
 export default () => {
+  let appElement = null;
+
+  beforeEach(() => {
+    appElement = document.createElement('div');
+    appElement.id = "app";
+    document.body.appendChild(appElement);
+
+    Modal.setAppElement("#app");
+  });
+
+  afterEach(() => {
+    document.body.removeChild(appElement);
+  });
+
   it("should trigger the onAfterOpen callback", () => {
     const afterOpenCallback = sinon.spy();
     withElementCollector(() => {
@@ -27,8 +41,8 @@ export default () => {
       const node = createHTMLElement("div");
       ReactDOM.render(<Modal {...props} />, node);
       requestAnimationFrame(() => {
-        afterOpenCallback.called.should.be.ok();
-        ReactDOM.unmountComponentAtNode(node);
+	afterOpenCallback.called.should.be.ok();
+	ReactDOM.unmountComponentAtNode(node);
       });
     });
   });
@@ -40,11 +54,11 @@ export default () => {
       const node = createHTMLElement("div");
       const modal = ReactDOM.render(<Modal {...props} />, node);
       requestAnimationFrame(() => {
-        sinon.assert.calledWith(afterOpenCallback, {
-          overlayEl: modal.portal.overlay,
-          contentEl: modal.portal.content
-        });
-        ReactDOM.unmountComponentAtNode(node);
+	sinon.assert.calledWith(afterOpenCallback, {
+	  overlayEl: modal.portal.overlay,
+	  contentEl: modal.portal.content
+	});
+	ReactDOM.unmountComponentAtNode(node);
       });
     });
   });
@@ -72,21 +86,21 @@ export default () => {
 
   it("keeps focus inside the modal when child has no tabbable elements", () => {
     let tabPrevented = false;
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, "hello", modal => {
       const content = mcontent(modal);
       document.activeElement.should.be.eql(content);
       tabKeyDown(content, {
-        preventDefault() {
-          tabPrevented = true;
-        }
+	preventDefault() {
+	  tabPrevented = true;
+	}
       });
       tabPrevented.should.be.eql(true);
     });
   });
 
   it("handles case when child has no tabbable elements", () => {
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, "hello", modal => {
       const content = mcontent(modal);
       tabKeyDown(content);
@@ -99,11 +113,11 @@ export default () => {
     const bottomButton = <button>bottom</button>;
     const modalContent = (
       <div>
-        {topButton}
-        {bottomButton}
+	{topButton}
+	{bottomButton}
       </div>
     );
-    const props = { isOpen: true }; 
+    const props = { isOpen: true };
     withModal(props, modalContent, modal => {
       const content = mcontent(modal);
       tabKeyDown(content, { shiftKey: true });
@@ -116,8 +130,8 @@ export default () => {
     const bottomButton = <button>bottom</button>;
     const modalContent = (
       <div>
-        {topButton}
-        {bottomButton}
+	{topButton}
+	{bottomButton}
       </div>
     );
     const props = { isOpen: true };
@@ -131,56 +145,56 @@ export default () => {
   describe("shouldCloseOnEsc", () => {
     context("when true", () => {
       it("should close on Esc key event", () => {
-        const requestCloseCallback = sinon.spy();
-        withModal(
-          {
-            isOpen: true,
-            shouldCloseOnEsc: true,
-            onRequestClose: requestCloseCallback
-          },
-          null,
-          modal => {
-            escKeyDown(mcontent(modal));
-            requestCloseCallback.called.should.be.ok();
-            // Check if event is passed to onRequestClose callback.
-            const event = requestCloseCallback.getCall(0).args[0];
-            event.should.be.ok();
-          }
-        );
+	const requestCloseCallback = sinon.spy();
+	withModal(
+	  {
+	    isOpen: true,
+	    shouldCloseOnEsc: true,
+	    onRequestClose: requestCloseCallback
+	  },
+	  null,
+	  modal => {
+	    escKeyDown(mcontent(modal));
+	    requestCloseCallback.called.should.be.ok();
+	    // Check if event is passed to onRequestClose callback.
+	    const event = requestCloseCallback.getCall(0).args[0];
+	    event.should.be.ok();
+	  }
+	);
       });
 
       it("should close on Esc key event with KeyboardEvent.code", () => {
-        const requestCloseCallback = sinon.spy();
-        withModal(
-          {
-            isOpen: true,
-            shouldCloseOnEsc: true,
-            onRequestClose: requestCloseCallback
-          },
-          null,
-          modal => {
-            escKeyDownWithCode(mcontent(modal));
-            requestCloseCallback.called.should.be.ok();
-            // Check if event is passed to onRequestClose callback.
-            const event = requestCloseCallback.getCall(0).args[0];
-            event.should.be.ok();
-          }
-        );
+	const requestCloseCallback = sinon.spy();
+	withModal(
+	  {
+	    isOpen: true,
+	    shouldCloseOnEsc: true,
+	    onRequestClose: requestCloseCallback
+	  },
+	  null,
+	  modal => {
+	    escKeyDownWithCode(mcontent(modal));
+	    requestCloseCallback.called.should.be.ok();
+	    // Check if event is passed to onRequestClose callback.
+	    const event = requestCloseCallback.getCall(0).args[0];
+	    event.should.be.ok();
+	  }
+	);
       });
     });
 
     context("when false", () => {
       it("should not close on Esc key event", () => {
-        const requestCloseCallback = sinon.spy();
-        const props = {
-          isOpen: true,
-          shouldCloseOnEsc: false,
-          onRequestClose: requestCloseCallback
-        };
-        withModal(props, null, modal => {
-          escKeyDown(mcontent(modal));
-          requestCloseCallback.called.should.be.false;
-        });
+	const requestCloseCallback = sinon.spy();
+	const props = {
+	  isOpen: true,
+	  shouldCloseOnEsc: false,
+	  onRequestClose: requestCloseCallback
+	};
+	withModal(props, null, modal => {
+	  escKeyDown(mcontent(modal));
+	  requestCloseCallback.called.should.be.false;
+	});
       });
     });
   });
@@ -189,54 +203,54 @@ export default () => {
     it("when false, click on overlay should not close", () => {
       const requestCloseCallback = sinon.spy();
       const props = {
-        isOpen: true,
-        shouldCloseOnOverlayClick: false
+	isOpen: true,
+	shouldCloseOnOverlayClick: false
       };
       withModal(props, null, modal => {
-        const overlay = moverlay(modal);
-        clickAt(overlay);
-        requestCloseCallback.called.should.not.be.ok();
+	const overlay = moverlay(modal);
+	clickAt(overlay);
+	requestCloseCallback.called.should.not.be.ok();
       });
     });
 
     it("when true, click on overlay must close", () => {
       const requestCloseCallback = sinon.spy();
       const props = {
-        isOpen: true,
-        shouldCloseOnOverlayClick: true,
-        onRequestClose: requestCloseCallback
+	isOpen: true,
+	shouldCloseOnOverlayClick: true,
+	onRequestClose: requestCloseCallback
       };
       withModal(props, null, modal => {
-        clickAt(moverlay(modal));
-        requestCloseCallback.called.should.be.ok();
+	clickAt(moverlay(modal));
+	requestCloseCallback.called.should.be.ok();
       });
     });
 
     it("overlay mouse down and content mouse up, should not close", () => {
       const requestCloseCallback = sinon.spy();
       const props = {
-        isOpen: true,
-        shouldCloseOnOverlayClick: true,
-        onRequestClose: requestCloseCallback
+	isOpen: true,
+	shouldCloseOnOverlayClick: true,
+	onRequestClose: requestCloseCallback
       };
       withModal(props, null, modal => {
-        mouseDownAt(moverlay(modal));
-        mouseUpAt(mcontent(modal));
-        requestCloseCallback.called.should.not.be.ok();
+	mouseDownAt(moverlay(modal));
+	mouseUpAt(mcontent(modal));
+	requestCloseCallback.called.should.not.be.ok();
       });
     });
 
     it("content mouse down and overlay mouse up, should not close", () => {
       const requestCloseCallback = sinon.spy();
       const props = {
-        isOpen: true,
-        shouldCloseOnOverlayClick: true,
-        onRequestClose: requestCloseCallback
+	isOpen: true,
+	shouldCloseOnOverlayClick: true,
+	onRequestClose: requestCloseCallback
       };
       withModal(props, null, modal => {
-        mouseDownAt(mcontent(modal));
-        mouseUpAt(moverlay(modal));
-        requestCloseCallback.called.should.not.be.ok();
+	mouseDownAt(mcontent(modal));
+	mouseUpAt(moverlay(modal));
+	requestCloseCallback.called.should.not.be.ok();
       });
     });
   });
@@ -267,8 +281,8 @@ export default () => {
     withModal(props, null, modal => {
       // click the overlay
       clickAt(moverlay(modal), {
-        // Used to test that this was the event received
-        fakeData: "ABC"
+	// Used to test that this was the event received
+	fakeData: "ABC"
       });
       requestCloseCallback.called.should.be.ok();
       // Check if event is passed to onRequestClose callback.
@@ -287,21 +301,21 @@ export default () => {
 
     withModal(
       {
-        isOpen: true,
-        onRequestClose: requestCloseCallback
+	isOpen: true,
+	onRequestClose: requestCloseCallback
       },
       <Modal
-        isOpen
-        onRequestClose={innerRequestCloseCallback}
-        ref={innerModalRef}
+	isOpen
+	onRequestClose={innerRequestCloseCallback}
+	ref={innerModalRef}
       >
-        <span>Test</span>
+	<span>Test</span>
       </Modal>,
       () => {
-        const content = mcontent(innerModal);
-        escKeyDown(content);
-        innerRequestCloseCallback.called.should.be.ok();
-        requestCloseCallback.called.should.not.be.ok();
+	const content = mcontent(innerModal);
+	escKeyDown(content);
+	innerRequestCloseCallback.called.should.be.ok();
+	requestCloseCallback.called.should.not.be.ok();
       }
     );
   });

--- a/specs/Modal.spec.js
+++ b/specs/Modal.spec.js
@@ -39,789 +39,801 @@ export default () => {
     ariaAppHiderResetState()
   ));
 
-  it("can be open initially", () => {
-    const props = { isOpen: true };
-    withModal(props, "hello", modal => {
-      mcontent(modal).should.be.ok();
-    });
-  });
-
-  it("can be closed initially", () => {
-    const props = {};
-    withModal(props, "hello", modal => {
-      should(ReactDOM.findDOMNode(mcontent(modal))).not.be.ok();
-    });
-  });
-
-  it("doesn't render the portal if modal is closed", () => {
-    const props = {};
-    withModal(props, "hello", modal => {
-      should(ReactDOM.findDOMNode(modal.portal)).not.be.ok();
-    });
-  });
-
-  it("has default props", () => {
-    withElementCollector(() => {
-      // eslint-disable-next-line react/no-render-return-value
-      const modal = <Modal />;
-      const props = modal.props;
-      props.isOpen.should.not.be.ok();
-      props.ariaHideApp.should.be.ok();
-      props.closeTimeoutMS.should.be.eql(0);
-      props.shouldFocusAfterRender.should.be.ok();
-      props.shouldCloseOnOverlayClick.should.be.ok();
-      props.preventScroll.should.be.false();
-    });
-  });
-
-  it("accepts appElement as a prop", () => {
-    withElementCollector(() => {
-      const el = createHTMLElement("div");
-      const props = {
-        isOpen: true,
-        ariaHideApp: true,
-        appElement: el
-      };
-      withModal(props, null, () => {
-        el.getAttribute("aria-hidden").should.be.eql("true");
-      });
-    });
-  });
-
-  it("accepts array of appElement as a prop", () => {
-    withElementCollector(() => {
-      const el1 = createHTMLElement("div");
-      const el2 = createHTMLElement("div");
-      const node = createHTMLElement("div");
-      ReactDOM.render(<Modal isOpen={true} appElement={[el1, el2]} />, node);
-      el1.getAttribute("aria-hidden").should.be.eql("true");
-      el2.getAttribute("aria-hidden").should.be.eql("true");
-      ReactDOM.unmountComponentAtNode(node);
-    });
-  });
-
-  it("renders into the body, not in context", () => {
-    withElementCollector(() => {
-      const node = createHTMLElement("div");
-      Modal.setAppElement(node);
-      ReactDOM.render(<Modal isOpen />, node);
-      document.body
-        .querySelector(".ReactModalPortal")
-        .parentNode.should.be.eql(document.body);
-      ReactDOM.unmountComponentAtNode(node);
-    });
-  });
-
-  it("allow setting appElement of type string", () => {
-    withElementCollector(() => {
-      const node = createHTMLElement("div");
-      const appElement = "body";
-      Modal.setAppElement(appElement);
-      ReactDOM.render(<Modal isOpen />, node);
-      document.body
-        .querySelector(".ReactModalPortal")
-        .parentNode.should.be.eql(document.body);
-      ReactDOM.unmountComponentAtNode(node);
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("allow setting appElement of type string matching multiple elements", () => {
-    withElementCollector(() => {
-      const el1 = createHTMLElement("div");
-      el1.id = "id1";
-      document.body.appendChild(el1);
-      const el2 = createHTMLElement("div");
-      el2.id = "id2";
-      document.body.appendChild(el2);
-      const node = createHTMLElement("div");
-      const appElement = "#id1, #id2";
-      Modal.setAppElement(appElement);
-      ReactDOM.render(<Modal isOpen />, node);
-      el1.getAttribute("aria-hidden").should.be.eql("true");
-      ReactDOM.unmountComponentAtNode(node);
-    });
-  });
-
-  it("default parentSelector should be document.body.", () => {
-    const props = { isOpen: true };
-    withModal(props, null, (modal) => {
-      modal.props.parentSelector().should.be.eql(document.body);
-    });
-  });
-
-  it("renders the modal content with a dialog aria role when provided ", () => {
-    const child = "I am a child of Modal, and he has sent me here...";
-    const props = { isOpen: true, role: "dialog" };
-    withModal(props, child, (modal) => {
-      contentAttribute(modal, "role").should.be.eql("dialog");
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("renders the modal content with the default aria role when not provided", () => {
-    const child = "I am a child of Modal, and he has sent me here...";
-    const props = { isOpen: true };
-    withModal(props, child, modal => {
-      contentAttribute(modal, "role").should.be.eql("dialog");
-    });
-  });
-
-  it("does not render the aria role when provided role with null", () => {
-    const child = "I am a child of Modal, and he has sent me here...";
-    const props = { isOpen: true, role: null };
-    withModal(props, child, modal => {
-      should(contentAttribute(modal, "role")).be.eql(null);
-    });
-  });
-
-  it("sets aria-label based on the contentLabel prop", () => {
-    const child = "I am a child of Modal, and he has sent me here...";
-    withModal(
-      {
-        isOpen: true,
-        contentLabel: "Special Modal"
-      },
-      child,
-      modal => {
-        contentAttribute(modal, "aria-label").should.be.eql("Special Modal");
-      }
-    );
-  });
-
-  it("removes the portal node", () => {
-    const props = { isOpen: true };
-    withModal(props, "hello");
-    should(document.querySelector(".ReactModalPortal")).not.be.ok();
-  });
-
-  it("removes the portal node after closeTimeoutMS", done => {
-    const closeTimeoutMS = 100;
-
-    function checkDOM(count) {
-      const portal = document.querySelectorAll(".ReactModalPortal");
-      portal.length.should.be.eql(count);
-    }
-
-    const props = { isOpen: true, closeTimeoutMS };
-    withModal(props, "hello", () => {
-      checkDOM(1);
-    });
-
-    setTimeout(() => {
-      // content is unmounted after specified timeout
-      checkDOM(0);
-      done();
-    }, closeTimeoutMS);
-  });
-
-  it("focuses the modal content by default", () => {
-    const props = { isOpen: true };
-    withModal(props, null, modal => {
-      document.activeElement.should.be.eql(mcontent(modal));
-    });
-  });
-
-  it("does not focus modal content if shouldFocusAfterRender is false", () => {
-    withModal(
-      { isOpen: true, shouldFocusAfterRender: false },
-      null,
-      modal => {
-        document.activeElement.should.not.be.eql(mcontent(modal));
-      }
-    );
-  });
-
-  it("give back focus to previous element or modal.", done => {
-    withModal(
-      {
-        isOpen: true,
-        className: "modal-a",
-        onRequestClose: function() { done(); }
-      },
-      null,
-      modalA => {
-        const modalContent = mcontent(modalA);
-        document.activeElement.should.be.eql(modalContent);
-
-        const modalB = withModal(
-          {
-            isOpen: true,
-            className: "modal-b",
-            onRequestClose() {
-              const modalContent = mcontent(modalB);
-              document.activeElement.should.be.eql(mcontent(modalA));
-              escKeyDown(modalContent);
-              document.activeElement.should.be.eql(modalContent);
-            }
-          },
-          null
+  describe("when missing app element", () => {
+    it("raise when not defined app element", () => {
+      should(() => {
+        const node = createHTMLElement("div");
+        ReactDOM.render(
+          <Modal isOpen={true} />,
+          node
         );
-        escKeyDown(modalContent);
-      }
-    );
-  });
-
-  it("does not steel focus when a descendent is already focused", () => {
-    let content;
-    const input = (
-      <input
-        ref={el => {
-          el && el.focus();
-          content = el;
-        }}
-      />
-    );
-    const props = { isOpen: true };
-    withModal(props, input, () => {
-      document.activeElement.should.be.eql(content);
+      }).throw();
     });
-  });
 
-  it("supports id prop", () => {
-    const props = { isOpen: true, id: "id" };
-    withModal(props, null, modal => {
-      mcontent(modal)
-        .id
-        .should.be.eql("id");
-    });
-  });
-
-  it("supports portalClassName", () => {
-    const props = {
-      isOpen: true,
-      portalClassName: "myPortalClass"
-    };
-    withModal(props, null, modal => {
-      modal.node.className.includes("myPortalClass").should.be.ok();
-    });
-  });
-
-  it("supports custom className", () => {
-    const props = { isOpen: true, className: "myClass" };
-    withModal(props, null, modal => {
-      mcontent(modal)
-        .className.includes("myClass")
-        .should.be.ok();
-    });
-  });
-
-  it("supports custom overlayElement", () => {
-    const overlayElement = (props, contentElement) => (
-      <div {...props} id="custom">
-        {contentElement}
-      </div>
-    );
-
-    const props = { isOpen: true, overlayElement };
-    withModal(props, null, modal => {
-      const modalOverlay = moverlay(modal);
-      modalOverlay.id.should.eql("custom");
-    });
-  });
-
-  it("supports custom contentElement", () => {
-    const contentElement = (props, children) => (
-      <div {...props} id="custom">
-        {children}
-      </div>
-    );
-
-    const props = { isOpen: true, contentElement };
-    withModal(props, "hello", modal => {
-      const modalContent = mcontent(modal);
-      modalContent.id.should.eql("custom");
-      modalContent.textContent.should.be.eql("hello");
-    });
-  });
-
-  it("supports overlayClassName", () => {
-    const props = {
-      isOpen: true,
-      overlayClassName: "myOverlayClass"
-    };
-    withModal(props, null, modal => {
-      moverlay(modal)
-        .className.includes("myOverlayClass")
-        .should.be.ok();
-    });
-  });
-
-  it("overrides content classes with custom object className", () => {
-    withElementCollector(() => {
-      const props = {
-        isOpen: true,
-        className: {
-          base: "myClass",
-          afterOpen: "myClass_after-open",
-          beforeClose: "myClass_before-close"
-        }
-      };
-      const node = createHTMLElement("div");
-      const modal = ReactDOM.render(<Modal {...props} />, node);
-      requestAnimationFrame(() => {
-        mcontent(modal).className.should.be.eql("myClass myClass_after-open");
-        ReactDOM.unmountComponentAtNode(node);
-      });
-    });
-  });
-
-  it("overrides overlay classes with custom object overlayClassName", () => {
-    withElementCollector(() => {
-      const props = {
-        isOpen: true,
-        overlayClassName: {
-          base: "myOverlayClass",
-          afterOpen: "myOverlayClass_after-open",
-          beforeClose: "myOverlayClass_before-close"
-        }
-      };
-      const node = createHTMLElement("div");
-      const modal = ReactDOM.render(<Modal {...props} />, node);
-      requestAnimationFrame(() => {
-        moverlay(modal).className.should.be.eql(
-          "myOverlayClass myOverlayClass_after-open"
+    it("raise when app element isn't found", () => {
+      should(() => {
+        const node = createHTMLElement("div");
+        ReactDOM.render(
+          <Modal isOpen={true} appElement={"meh"} />,
+          node
         );
-        ReactDOM.unmountComponentAtNode(node);
-      });
+      }).throw();
     });
   });
 
-  it("supports overriding react modal open class in document.body.", () => {
-    const props = { isOpen: true, bodyOpenClassName: "custom-modal-open" };
-    withModal(props, null, () => {
-      (document.body.className.indexOf("custom-modal-open") > -1).should.be.ok();
-    });
-  });
+  describe("app element defined", () => {
+    let appElement = null;
 
-  it("supports setting react modal open class in <html />.", () => {
-    const props = { isOpen: true, htmlOpenClassName: "custom-modal-open" };
-    withModal(props, null, () => {
-      isHtmlWithReactModalOpenClass("custom-modal-open").should.be.ok();
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("don't append class to document.body if modal is closed.", () => {
-    const props = { isOpen: false };
-    withModal(props, null, () => {
-      isDocumentWithReactModalOpenClass().should.not.be.ok();
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("don't append any class to document.body when bodyOpenClassName is null.", () => {
-    const props = { isOpen: true, bodyOpenClassName: null };
-    withModal(props, null, () => {
-      documentClassList().should.be.empty();
-    });
-  });
-
-  it("don't append class to <html /> if modal is closed.", () => {
-    const props = { isOpen: false, htmlOpenClassName: "custom-modal-open" };
-    withModal(props, null, () => {
-      isHtmlWithReactModalOpenClass().should.not.be.ok();
-    });
-  });
-
-  it("append class to document.body if modal is open.", () => {
-    const props = { isOpen: true };
-    withModal(props, null, () => {
-      isDocumentWithReactModalOpenClass().should.be.ok();
-    });
-  });
-
-  it("don't append class to <html /> if not defined.", () => {
-    const props = { isOpen: true };
-    withModal(props, null, () => {
-      htmlClassList().should.be.empty();
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("removes class from document.body when unmounted without closing", () => {
-    withModal({ isOpen: true });
-    isDocumentWithReactModalOpenClass().should.not.be.ok();
-  });
-
-  it("remove class from document.body when no modals opened", () => {
-    const propsA = { isOpen: true };
-    withModal(propsA, null, () => {
-      isDocumentWithReactModalOpenClass().should.be.ok();
-    });
-    const propsB = { isOpen: true };
-    withModal(propsB, null, () => {
-      isDocumentWithReactModalOpenClass().should.be.ok();
-    });
-    isDocumentWithReactModalOpenClass().should.not.be.ok();
-    isHtmlWithReactModalOpenClass().should.not.be.ok();
-  });
-
-  it("supports adding/removing multiple document.body classes", () => {
-    const props = {
-      isOpen: true,
-      bodyOpenClassName: "A B C"
-    };
-    withModal(props, null, () => {
-      document.body.classList.contains("A", "B", "C").should.be.ok();
-    });
-    document.body.classList.contains("A", "B", "C").should.not.be.ok();
-    ;
-  });
-
-  it("does not remove shared classes if more than one modal is open", () => {
-    const props = {
-      isOpen: true,
-      bodyOpenClassName: "A"
-    };
-    withModal(props, null, () => {
-      isDocumentWithReactModalOpenClass("A").should.be.ok();
-      withModal({
-        isOpen: true,
-        bodyOpenClassName: "A B"
-      }, null, () => {
-        isDocumentWithReactModalOpenClass("A B").should.be.ok();
-      });
-      isDocumentWithReactModalOpenClass("A").should.be.ok();
-    });
-    isDocumentWithReactModalOpenClass("A").should.not.be.ok();
-  });
-
-  it("should not add classes to document.body for unopened modals", () => {
-    const props = { isOpen: true };
-    withModal(props, null, () => {
-      isDocumentWithReactModalOpenClass().should.be.ok();
-    });
-    withModal({ isOpen: false, bodyOpenClassName: "testBodyClass" });
-    isDocumentWithReactModalOpenClass("testBodyClass").should.not.be.ok();
-  });
-
-  it("should not remove classes from document.body if modal is closed", () => {
-    const props = { isOpen: true };
-    withModal(props, null, () => {
-      isDocumentWithReactModalOpenClass().should.be.ok();
-      withModal({ isOpen: false, bodyOpenClassName: "testBodyClass" }, null, () => {
-        isDocumentWithReactModalOpenClass("testBodyClass").should.not.be.ok();
-      });
-      isDocumentWithReactModalOpenClass().should.be.ok();
-    });
-  });
-
-  it("should not remove classes from <html /> if modal is closed", () => {
-    const props = { isOpen: false };
-    withModal(props, null, () => {
-      isHtmlWithReactModalOpenClass().should.not.be.ok();
-      withModal({
-        isOpen: true,
-        htmlOpenClassName: "testHtmlClass"
-      }, null, () => {
-        isHtmlWithReactModalOpenClass("testHtmlClass").should.be.ok();
-      });
-      isHtmlWithReactModalOpenClass("testHtmlClass").should.not.be.ok();
-    });
-  });
-
-  it("additional aria attributes", () => {
-    withModal(
-      { isOpen: true, aria: { labelledby: "a" } },
-      "hello",
-      modal => mcontent(modal)
-        .getAttribute("aria-labelledby")
-        .should.be.eql("a")
-    );
-  });
-
-  it("additional data attributes", () => {
-    withModal(
-      { isOpen: true, data: { background: "green" } },
-      "hello",
-      modal => mcontent(modal)
-        .getAttribute("data-background")
-        .should.be.eql("green")
-    );
-  });
-
-  it("additional testId attribute", () => {
-    withModal(
-      { isOpen: true, testId: "foo-bar" },
-      "hello",
-      modal => mcontent(modal)
-        .getAttribute("data-testid")
-        .should.be.eql("foo-bar")
-    )
-  });
-
-  it("raises an exception if the appElement selector does not match", () => {
-    should(() => ariaAppSetElement(".test")).throw();
-  });
-
-  it.skip("removes aria-hidden from appElement when unmounted w/o closing", () => {
-    withElementCollector(() => {
-      const el = createHTMLElement("div");
-      const node = createHTMLElement("div");
-      ReactDOM.render(<Modal isOpen appElement={el} />, node);
-      ReactDOM.unmountComponentAtNode(node);
-      should(el.getAttribute("aria-hidden")).be.eql(null);
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it.skip("removes aria-hidden when closed and another modal with ariaHideApp set to false is open", () => {
-    withElementCollector(() => {
-      const rootNode = createHTMLElement("div");
-      const appElement = createHTMLElement("div");
-      document.body.appendChild(rootNode);
+    beforeEach(() => {
+      appElement = document.createElement('div');
+      appElement.id = "app";
       document.body.appendChild(appElement);
 
-      Modal.setAppElement(appElement);
-
-      const initialState = (
-        <div>
-          <Modal isOpen={true} ariaHideApp={false} id="test-1-modal-1" />
-          <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-2" />
-        </div>
-      );
-
-      ReactDOM.render(initialState, rootNode);
-      appElement.getAttribute("aria-hidden").should.be.eql("true");
-
-      const updatedState = (
-        <div>
-          <Modal isOpen={true} ariaHideApp={false} id="test-1-modal-1" />
-          <Modal isOpen={false} ariaHideApp={true} id="test-1-modal-2" />
-        </div>
-      );
-
-      ReactDOM.render(updatedState, rootNode);
-      should(appElement.getAttribute("aria-hidden")).not.be.ok();
-
-      ReactDOM.unmountComponentAtNode(rootNode);
+      Modal.setAppElement("#app");
     });
-  });
 
-  // eslint-disable-next-line max-len
-  it("maintains aria-hidden when closed and another modal with ariaHideApp set to true is open", () => {
-    withElementCollector(() => {
-      const rootNode = createHTMLElement("div");
-      document.body.appendChild(rootNode);
-
-      const appElement = createHTMLElement("div");
-      document.body.appendChild(appElement);
-
-      Modal.setAppElement(appElement);
-
-      const initialState = (
-        <div>
-          <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-1" />
-          <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-2" />
-        </div>
-      );
-
-      ReactDOM.render(initialState, rootNode);
-      appElement.getAttribute("aria-hidden").should.be.eql("true");
-
-      const updatedState = (
-        <div>
-          <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-1" />
-          <Modal isOpen={false} ariaHideApp={true} id="test-1-modal-2" />
-        </div>
-      );
-
-      ReactDOM.render(updatedState, rootNode);
-      appElement.getAttribute("aria-hidden").should.be.eql("true");
-
-      ReactDOM.unmountComponentAtNode(rootNode);
+    afterEach(() => {
+      document.body.removeChild(appElement);
     });
-  });
 
-  // eslint-disable-next-line max-len
-  it.skip("removes aria-hidden when unmounted without close and second modal with ariaHideApp=false is open", () => {
-    withElementCollector(() => {
-      const appElement = createHTMLElement("div");
-      document.body.appendChild(appElement);
-      Modal.setAppElement(appElement);
-
-      const propsA = { isOpen: true, ariaHideApp: false, id: "test-2-modal-1" };
-      withModal(propsA, null, () => {
-        should(appElement.getAttribute("aria-hidden")).not.be.ok();
-      });
-
-      const propsB = { isOpen: true, ariaHideApp: true, id: "test-2-modal-2" };
-      withModal(propsB, null, () => {
-        appElement.getAttribute("aria-hidden").should.be.eql("true");
-      });
-
-      should(appElement.getAttribute("aria-hidden")).not.be.ok();
-    });
-  });
-
-  // eslint-disable-next-line max-len
-  it("maintains aria-hidden when unmounted without close and second modal with ariaHideApp=true is open", () => {
-    withElementCollector(() => {
-      const appElement = createHTMLElement("div");
-      document.body.appendChild(appElement);
-      Modal.setAppElement(appElement);
-
-      const check = (tobe) => appElement.getAttribute("aria-hidden").should.be.eql(tobe);
-
-      const props = { isOpen: true, ariaHideApp: true, id: "test-3-modal-1" };
-      withModal(props, null, () => {
-        check("true");
-        withModal({ isOpen: true, ariaHideApp: true, id: "test-3-modal-2" }, null, () => {
-          check("true");
-        });
-        check("true");
-      });
-      should(appElement.getAttribute("aria-hidden")).not.be.ok();
-    });
-  });
-
-  it("adds --after-open for animations", () => {
-    withElementCollector(() => {
-      const rg = /--after-open/i;
+    it("can be open initially", () => {
       const props = { isOpen: true };
-      const node = createHTMLElement("div");
-      const modal = ReactDOM.render(<Modal {...props} />, node);
-      requestAnimationFrame(() => {
-        const contentName = modal.portal.content.className;
-        const overlayName = modal.portal.overlay.className;
-        rg.test(contentName).should.be.ok();
-        rg.test(overlayName).should.be.ok();
+      withModal(props, "hello", modal => {
+        mcontent(modal).should.be.ok();
+      });
+    });
+
+    it("can be closed initially", () => {
+      const props = {};
+      withModal(props, "hello", modal => {
+        should(ReactDOM.findDOMNode(mcontent(modal))).not.be.ok();
+      });
+    });
+
+    it("doesn't render the portal if modal is closed", () => {
+      const props = {};
+      withModal(props, "hello", modal => {
+        should(ReactDOM.findDOMNode(modal.portal)).not.be.ok();
+      });
+    });
+
+    it("has default props", () => {
+      withElementCollector(() => {
+        // eslint-disable-next-line react/no-render-return-value
+        const modal = <Modal />;
+        const props = modal.props;
+        props.isOpen.should.not.be.ok();
+        props.ariaHideApp.should.be.ok();
+        props.closeTimeoutMS.should.be.eql(0);
+        props.shouldFocusAfterRender.should.be.ok();
+        props.shouldCloseOnOverlayClick.should.be.ok();
+        props.preventScroll.should.be.false();
+      });
+    });
+
+    it("accepts appElement as a prop", () => {
+      withElementCollector(() => {
+        const el = createHTMLElement("div");
+        const props = {
+          isOpen: true,
+          ariaHideApp: true,
+          appElement: el
+        };
+        withModal(props, null, () => {
+          el.getAttribute("aria-hidden").should.be.eql("true");
+        });
+      });
+    });
+
+    it("accepts array of appElement as a prop", () => {
+      withElementCollector(() => {
+        const el1 = createHTMLElement("div");
+        const el2 = createHTMLElement("div");
+        const node = createHTMLElement("div");
+        ReactDOM.render(
+          <Modal isOpen={true} appElement={[el1, el2]} />,
+          node
+        );
+        el1.getAttribute("aria-hidden").should.be.eql("true");
+        el2.getAttribute("aria-hidden").should.be.eql("true");
         ReactDOM.unmountComponentAtNode(node);
       });
     });
-  });
 
-  it("adds --before-close for animations", () => {
-    const closeTimeoutMS = 50;
-    const props = {
-      isOpen: true,
-      closeTimeoutMS
-    };
-    withModal(props, null, modal => {
-      modal.portal.closeWithTimeout();
-
-      const rg = /--before-close/i;
-      rg.test(moverlay(modal).className).should.be.ok();
-      rg.test(mcontent(modal).className).should.be.ok();
-
-      modal.portal.closeWithoutTimeout();
+    it("allow setting appElement of type string matching multiple elements", () => {
+      withElementCollector(() => {
+        const el1 = createHTMLElement("div");
+        el1.id = "id1";
+        document.body.appendChild(el1);
+        const el2 = createHTMLElement("div");
+        el2.id = "id2";
+        document.body.appendChild(el2);
+        const node = createHTMLElement("div");
+        const appElement = "#id1, #id2";
+        Modal.setAppElement(appElement);
+        ReactDOM.render(<Modal isOpen />, node);
+        el1.getAttribute("aria-hidden").should.be.eql("true");
+        el2.getAttribute("aria-hidden").should.be.eql("true");
+        ReactDOM.unmountComponentAtNode(node);
+      });
     });
-  });
 
-  it("should not be open after close with time out and reopen it", () => {
-    const props = {
-      isOpen: true,
-      closeTimeoutMS: 2000,
-      onRequestClose() { }
-    };
-    withModal(props, null, modal => {
-      modal.portal.closeWithTimeout();
-      modal.portal.open();
-      modal.portal.closeWithoutTimeout();
-      modal.portal.state.isOpen.should.not.be.ok();
+    it("default parentSelector should be document.body.", () => {
+      const props = { isOpen: true };
+      withModal(props, null, (modal) => {
+        modal.props.parentSelector().should.be.eql(document.body);
+      });
     });
-  });
 
-  it("verify default prop of shouldCloseOnOverlayClick", () => {
-    const props = { isOpen: true };
-    withModal(props, null, modal => {
-      modal.props.shouldCloseOnOverlayClick.should.be.ok();
+    it("renders the modal content with a dialog aria role when provided ", () => {
+      const child = "I am a child of Modal, and he has sent me here...";
+      const props = { isOpen: true, role: "dialog" };
+      withModal(props, child, (modal) => {
+        contentAttribute(modal, "role").should.be.eql("dialog");
+      });
     });
-  });
 
-  it("verify prop of shouldCloseOnOverlayClick", () => {
-    const modalOpts = { isOpen: true, shouldCloseOnOverlayClick: false };
-    withModal(modalOpts, null, modal => {
-      modal.props.shouldCloseOnOverlayClick.should.not.be.ok();
+    // eslint-disable-next-line max-len
+    it("renders the modal content with the default aria role when not provided", () => {
+      const child = "I am a child of Modal, and he has sent me here...";
+      const props = { isOpen: true };
+      withModal(props, child, modal => {
+        contentAttribute(modal, "role").should.be.eql("dialog");
+      });
     });
-  });
 
-  it("keeps the modal in the DOM until closeTimeoutMS elapses", done => {
-    function checkDOM(count) {
-      const overlay = document.querySelectorAll(".ReactModal__Overlay");
-      const content = document.querySelectorAll(".ReactModal__Content");
-      overlay.length.should.be.eql(count);
-      content.length.should.be.eql(count);
-    }
-    withElementCollector(() => {
+    it("does not render the aria role when provided role with null", () => {
+      const child = "I am a child of Modal, and he has sent me here...";
+      const props = { isOpen: true, role: null };
+      withModal(props, child, modal => {
+        should(contentAttribute(modal, "role")).be.eql(null);
+      });
+    });
+
+    it("sets aria-label based on the contentLabel prop", () => {
+      const child = "I am a child of Modal, and he has sent me here...";
+      withModal(
+        {
+          isOpen: true,
+          contentLabel: "Special Modal"
+        },
+        child,
+        modal => {
+          contentAttribute(modal, "aria-label").should.be.eql("Special Modal");
+        }
+      );
+    });
+
+    it("removes the portal node", () => {
+      const props = { isOpen: true };
+      withModal(props, "hello");
+      should(document.querySelector(".ReactModalPortal")).not.be.ok();
+    });
+
+    it("removes the portal node after closeTimeoutMS", done => {
       const closeTimeoutMS = 100;
-      const props = { isOpen: true, closeTimeoutMS };
-      const node = createHTMLElement("div");
-      const modal = ReactDOM.render(<Modal {...props} />, node);
 
-      modal.portal.closeWithTimeout();
-      checkDOM(1);
+      function checkDOM(count) {
+        const portal = document.querySelectorAll(".ReactModalPortal");
+        portal.length.should.be.eql(count);
+      }
+
+      const props = { isOpen: true, closeTimeoutMS };
+      withModal(props, "hello", () => {
+        checkDOM(1);
+      });
 
       setTimeout(() => {
+        // content is unmounted after specified timeout
         checkDOM(0);
-        ReactDOM.unmountComponentAtNode(node);
         done();
       }, closeTimeoutMS);
     });
-  });
 
-  it("verify that portalClassName is refreshed on component update", () => {
-    withElementCollector(() => {
-      const node = createHTMLElement("div");
-      let modal = null;
-
-      class App extends Component {
-        constructor(props) {
-          super(props);
-          this.state = { classModifier: "" };
-        }
-
-        componentDidMount() {
-          modal.node.className.should.be.eql("portal");
-
-          this.setState({ classModifier: "-modifier" });
-        }
-
-        componentDidUpdate() {
-          modal.node.className.should.be.eql("portal-modifier");
-        }
-
-        render() {
-          const { classModifier } = this.state;
-          const portalClassName = `portal${classModifier}`;
-
-          return (
-            <div>
-              <Modal
-                ref={modalComponent => {
-                  modal = modalComponent;
-                }}
-                isOpen
-                portalClassName={portalClassName}
-              >
-                <span>Test</span>
-              </Modal>
-            </div>
-          );
-        }
-      }
-
-      Modal.setAppElement(node);
-      ReactDOM.render(<App />, node);
-      ReactDOM.unmountComponentAtNode(node);
+    it("focuses the modal content by default", () => {
+      const props = { isOpen: true };
+      withModal(props, null, modal => {
+        document.activeElement.should.be.eql(mcontent(modal));
+      });
     });
-  });
 
-  it("use overlayRef and contentRef", () => {
-    let overlay = null;
-    let content = null;
+    it("does not focus modal content if shouldFocusAfterRender is false", () => {
+      withModal(
+        { isOpen: true, shouldFocusAfterRender: false },
+        null,
+        modal => {
+          document.activeElement.should.not.be.eql(mcontent(modal));
+        }
+      );
+    });
 
-    const props = {
-      isOpen: true,
-      overlayRef: node => (overlay = node),
-      contentRef: node => (content = node)
-    };
-    withModal(props, null, () => {
-      overlay.should.be.instanceOf(HTMLElement);
-      content.should.be.instanceOf(HTMLElement);
-      overlay.classList.contains("ReactModal__Overlay");
-      content.classList.contains("ReactModal__Content");
+    it("give back focus to previous element or modal.", done => {
+      withModal(
+        {
+          isOpen: true,
+          className: "modal-a",
+          onRequestClose: function() { done(); }
+        },
+        null,
+        modalA => {
+          const modalContent = mcontent(modalA);
+          document.activeElement.should.be.eql(modalContent);
+
+          const modalB = withModal(
+            {
+              isOpen: true,
+              className: "modal-b",
+              onRequestClose() {
+                const modalContent = mcontent(modalB);
+                document.activeElement.should.be.eql(mcontent(modalA));
+                escKeyDown(modalContent);
+                document.activeElement.should.be.eql(modalContent);
+              }
+            },
+            null
+          );
+          escKeyDown(modalContent);
+        }
+      );
+    });
+
+    it("does not steel focus when a descendent is already focused", () => {
+      let content;
+      const input = (
+        <input
+          ref={el => {
+            el && el.focus();
+            content = el;
+          }}
+        />
+      );
+      const props = { isOpen: true };
+      withModal(props, input, () => {
+        document.activeElement.should.be.eql(content);
+      });
+    });
+
+    it("supports id prop", () => {
+      const props = { isOpen: true, id: "id" };
+      withModal(props, null, modal => {
+        mcontent(modal)
+          .id
+          .should.be.eql("id");
+      });
+    });
+
+    it("supports portalClassName", () => {
+      const props = {
+        isOpen: true,
+        portalClassName: "myPortalClass"
+      };
+      withModal(props, null, modal => {
+        modal.node.className.includes("myPortalClass").should.be.ok();
+      });
+    });
+
+    it("supports custom className", () => {
+      const props = { isOpen: true, className: "myClass" };
+      withModal(props, null, modal => {
+        mcontent(modal)
+          .className.includes("myClass")
+          .should.be.ok();
+      });
+    });
+
+    it("supports custom overlayElement", () => {
+      const overlayElement = (props, contentElement) => (
+        <div {...props} id="custom">
+          {contentElement}
+        </div>
+      );
+
+      const props = { isOpen: true, overlayElement };
+      withModal(props, null, modal => {
+        const modalOverlay = moverlay(modal);
+        modalOverlay.id.should.eql("custom");
+      });
+    });
+
+    it("supports custom contentElement", () => {
+      const contentElement = (props, children) => (
+        <div {...props} id="custom">
+          {children}
+        </div>
+      );
+
+      const props = { isOpen: true, contentElement };
+      withModal(props, "hello", modal => {
+        const modalContent = mcontent(modal);
+        modalContent.id.should.eql("custom");
+        modalContent.textContent.should.be.eql("hello");
+      });
+    });
+
+    it("supports overlayClassName", () => {
+      const props = {
+        isOpen: true,
+        overlayClassName: "myOverlayClass"
+      };
+      withModal(props, null, modal => {
+        moverlay(modal)
+          .className.includes("myOverlayClass")
+          .should.be.ok();
+      });
+    });
+
+    it("overrides content classes with custom object className", () => {
+      withElementCollector(() => {
+        const props = {
+          isOpen: true,
+          className: {
+            base: "myClass",
+            afterOpen: "myClass_after-open",
+            beforeClose: "myClass_before-close"
+          }
+        };
+        const node = createHTMLElement("div");
+        const modal = ReactDOM.render(<Modal {...props} />, node);
+        requestAnimationFrame(() => {
+          mcontent(modal).className.should.be.eql("myClass myClass_after-open");
+          ReactDOM.unmountComponentAtNode(node);
+        });
+      });
+    });
+
+    it("overrides overlay classes with custom object overlayClassName", () => {
+      withElementCollector(() => {
+        const props = {
+          isOpen: true,
+          overlayClassName: {
+            base: "myOverlayClass",
+            afterOpen: "myOverlayClass_after-open",
+            beforeClose: "myOverlayClass_before-close"
+          }
+        };
+        const node = createHTMLElement("div");
+        const modal = ReactDOM.render(<Modal {...props} />, node);
+        requestAnimationFrame(() => {
+          moverlay(modal).className.should.be.eql(
+            "myOverlayClass myOverlayClass_after-open"
+          );
+          ReactDOM.unmountComponentAtNode(node);
+        });
+      });
+    });
+
+    it("supports overriding react modal open class in document.body.", () => {
+      const props = { isOpen: true, bodyOpenClassName: "custom-modal-open" };
+      withModal(props, null, () => {
+        (document.body.className.indexOf("custom-modal-open") > -1).should.be.ok();
+      });
+    });
+
+    it("supports setting react modal open class in <html />.", () => {
+      const props = { isOpen: true, htmlOpenClassName: "custom-modal-open" };
+      withModal(props, null, () => {
+        isHtmlWithReactModalOpenClass("custom-modal-open").should.be.ok();
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("don't append class to document.body if modal is closed.", () => {
+      const props = { isOpen: false };
+      withModal(props, null, () => {
+        isDocumentWithReactModalOpenClass().should.not.be.ok();
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("don't append any class to document.body when bodyOpenClassName is null.", () => {
+      const props = { isOpen: true, bodyOpenClassName: null };
+      withModal(props, null, () => {
+        documentClassList().should.be.empty();
+      });
+    });
+
+    it("don't append class to <html /> if modal is closed.", () => {
+      const props = { isOpen: false, htmlOpenClassName: "custom-modal-open" };
+      withModal(props, null, () => {
+        isHtmlWithReactModalOpenClass().should.not.be.ok();
+      });
+    });
+
+    it("append class to document.body if modal is open.", () => {
+      const props = { isOpen: true };
+      withModal(props, null, () => {
+        isDocumentWithReactModalOpenClass().should.be.ok();
+      });
+    });
+
+    it("don't append class to <html /> if not defined.", () => {
+      const props = { isOpen: true };
+      withModal(props, null, () => {
+        htmlClassList().should.be.empty();
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("removes class from document.body when unmounted without closing", () => {
+      withModal({ isOpen: true });
+      isDocumentWithReactModalOpenClass().should.not.be.ok();
+    });
+
+    it("remove class from document.body when no modals opened", () => {
+      const propsA = { isOpen: true };
+      withModal(propsA, null, () => {
+        isDocumentWithReactModalOpenClass().should.be.ok();
+      });
+      const propsB = { isOpen: true };
+      withModal(propsB, null, () => {
+        isDocumentWithReactModalOpenClass().should.be.ok();
+      });
+      isDocumentWithReactModalOpenClass().should.not.be.ok();
+      isHtmlWithReactModalOpenClass().should.not.be.ok();
+    });
+
+    it("supports adding/removing multiple document.body classes", () => {
+      const props = {
+        isOpen: true,
+        bodyOpenClassName: "A B C"
+      };
+      withModal(props, null, () => {
+        document.body.classList.contains("A", "B", "C").should.be.ok();
+      });
+      document.body.classList.contains("A", "B", "C").should.not.be.ok();
+      ;
+    });
+
+    it("does not remove shared classes if more than one modal is open", () => {
+      const props = {
+        isOpen: true,
+        bodyOpenClassName: "A"
+      };
+      withModal(props, null, () => {
+        isDocumentWithReactModalOpenClass("A").should.be.ok();
+        withModal({
+          isOpen: true,
+          bodyOpenClassName: "A B"
+        }, null, () => {
+          isDocumentWithReactModalOpenClass("A B").should.be.ok();
+        });
+        isDocumentWithReactModalOpenClass("A").should.be.ok();
+      });
+      isDocumentWithReactModalOpenClass("A").should.not.be.ok();
+    });
+
+    it("should not add classes to document.body for unopened modals", () => {
+      const props = { isOpen: true };
+      withModal(props, null, () => {
+        isDocumentWithReactModalOpenClass().should.be.ok();
+      });
+      withModal({ isOpen: false, bodyOpenClassName: "testBodyClass" });
+      isDocumentWithReactModalOpenClass("testBodyClass").should.not.be.ok();
+    });
+
+    it("should not remove classes from document.body if modal is closed", () => {
+      const props = { isOpen: true };
+      withModal(props, null, () => {
+        isDocumentWithReactModalOpenClass().should.be.ok();
+        withModal({ isOpen: false, bodyOpenClassName: "testBodyClass" }, null, () => {
+          isDocumentWithReactModalOpenClass("testBodyClass").should.not.be.ok();
+        });
+        isDocumentWithReactModalOpenClass().should.be.ok();
+      });
+    });
+
+    it("should not remove classes from <html /> if modal is closed", () => {
+      const props = { isOpen: false };
+      withModal(props, null, () => {
+        isHtmlWithReactModalOpenClass().should.not.be.ok();
+        withModal({
+          isOpen: true,
+          htmlOpenClassName: "testHtmlClass"
+        }, null, () => {
+          isHtmlWithReactModalOpenClass("testHtmlClass").should.be.ok();
+        });
+        isHtmlWithReactModalOpenClass("testHtmlClass").should.not.be.ok();
+      });
+    });
+
+    it("additional aria attributes", () => {
+      withModal(
+        { isOpen: true, aria: { labelledby: "a" } },
+        "hello",
+        modal => mcontent(modal)
+          .getAttribute("aria-labelledby")
+          .should.be.eql("a")
+      );
+    });
+
+    it("additional data attributes", () => {
+      withModal(
+        { isOpen: true, data: { background: "green" } },
+        "hello",
+        modal => mcontent(modal)
+          .getAttribute("data-background")
+          .should.be.eql("green")
+      );
+    });
+
+    it("additional testId attribute", () => {
+      withModal(
+        { isOpen: true, testId: "foo-bar" },
+        "hello",
+        modal => mcontent(modal)
+          .getAttribute("data-testid")
+          .should.be.eql("foo-bar")
+      )
+    });
+
+    it.skip("removes aria-hidden from appElement when unmounted w/o closing", () => {
+      withElementCollector(() => {
+        const el = createHTMLElement("div");
+        const node = createHTMLElement("div");
+        ReactDOM.render(<Modal isOpen appElement={el} />, node);
+        ReactDOM.unmountComponentAtNode(node);
+        should(el.getAttribute("aria-hidden")).be.eql(null);
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it.skip("removes aria-hidden when closed and another modal with ariaHideApp set to false is open", () => {
+      withElementCollector(() => {
+        const rootNode = createHTMLElement("div");
+        const appElement = createHTMLElement("div");
+        document.body.appendChild(rootNode);
+        document.body.appendChild(appElement);
+
+        Modal.setAppElement(appElement);
+
+        const initialState = (
+          <div>
+            <Modal isOpen={true} ariaHideApp={false} id="test-1-modal-1" />
+            <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-2" />
+          </div>
+        );
+
+        ReactDOM.render(initialState, rootNode);
+        appElement.getAttribute("aria-hidden").should.be.eql("true");
+
+        const updatedState = (
+          <div>
+            <Modal isOpen={true} ariaHideApp={false} id="test-1-modal-1" />
+            <Modal isOpen={false} ariaHideApp={true} id="test-1-modal-2" />
+          </div>
+        );
+
+        ReactDOM.render(updatedState, rootNode);
+        should(appElement.getAttribute("aria-hidden")).not.be.ok();
+
+        ReactDOM.unmountComponentAtNode(rootNode);
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("maintains aria-hidden when closed and another modal with ariaHideApp set to true is open", () => {
+      withElementCollector(() => {
+        const rootNode = createHTMLElement("div");
+        document.body.appendChild(rootNode);
+
+        const appElement = createHTMLElement("div");
+        document.body.appendChild(appElement);
+
+        Modal.setAppElement(appElement);
+
+        const initialState = (
+          <div>
+            <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-1" />
+            <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-2" />
+          </div>
+        );
+
+        ReactDOM.render(initialState, rootNode);
+        appElement.getAttribute("aria-hidden").should.be.eql("true");
+
+        const updatedState = (
+          <div>
+            <Modal isOpen={true} ariaHideApp={true} id="test-1-modal-1" />
+            <Modal isOpen={false} ariaHideApp={true} id="test-1-modal-2" />
+          </div>
+        );
+
+        ReactDOM.render(updatedState, rootNode);
+        appElement.getAttribute("aria-hidden").should.be.eql("true");
+
+        ReactDOM.unmountComponentAtNode(rootNode);
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("removes aria-hidden when unmounted without close and second modal with ariaHideApp=false is open", () => {
+      withElementCollector(() => {
+        const appElement = createHTMLElement("div");
+        document.body.appendChild(appElement);
+        Modal.setAppElement(appElement);
+
+        const propsA = { isOpen: true, ariaHideApp: false, id: "test-2-modal-1" };
+        withModal(propsA, null, () => {
+          should(appElement.getAttribute("aria-hidden")).not.be.ok();
+        });
+
+        const propsB = { isOpen: true, ariaHideApp: true, id: "test-2-modal-2" };
+        withModal(propsB, null, () => {
+          appElement.getAttribute("aria-hidden").should.be.eql("true");
+        });
+
+        should(appElement.getAttribute("aria-hidden")).not.be.ok();
+      });
+    });
+
+    // eslint-disable-next-line max-len
+    it("maintains aria-hidden when unmounted without close and second modal with ariaHideApp=true is open", () => {
+      withElementCollector(() => {
+        const appElement = createHTMLElement("div");
+        document.body.appendChild(appElement);
+        Modal.setAppElement(appElement);
+
+        const check = (tobe) => appElement.getAttribute("aria-hidden").should.be.eql(tobe);
+
+        const props = { isOpen: true, ariaHideApp: true, id: "test-3-modal-1" };
+        withModal(props, null, () => {
+          check("true");
+          withModal({ isOpen: true, ariaHideApp: true, id: "test-3-modal-2" }, null, () => {
+            check("true");
+          });
+          check("true");
+        });
+        should(appElement.getAttribute("aria-hidden")).not.be.ok();
+      });
+    });
+
+    it("adds --after-open for animations", () => {
+      withElementCollector(() => {
+        const rg = /--after-open/i;
+        const props = { isOpen: true };
+        const node = createHTMLElement("div");
+        const modal = ReactDOM.render(<Modal {...props} />, node);
+        requestAnimationFrame(() => {
+          const contentName = modal.portal.content.className;
+          const overlayName = modal.portal.overlay.className;
+          rg.test(contentName).should.be.ok();
+          rg.test(overlayName).should.be.ok();
+          ReactDOM.unmountComponentAtNode(node);
+        });
+      });
+    });
+
+    it("adds --before-close for animations", () => {
+      const closeTimeoutMS = 50;
+      const props = {
+        isOpen: true,
+        closeTimeoutMS
+      };
+      withModal(props, null, modal => {
+        modal.portal.closeWithTimeout();
+
+        const rg = /--before-close/i;
+        rg.test(moverlay(modal).className).should.be.ok();
+        rg.test(mcontent(modal).className).should.be.ok();
+
+        modal.portal.closeWithoutTimeout();
+      });
+    });
+
+    it("should not be open after close with time out and reopen it", () => {
+      const props = {
+        isOpen: true,
+        closeTimeoutMS: 2000,
+        onRequestClose() { }
+      };
+      withModal(props, null, modal => {
+        modal.portal.closeWithTimeout();
+        modal.portal.open();
+        modal.portal.closeWithoutTimeout();
+        modal.portal.state.isOpen.should.not.be.ok();
+      });
+    });
+
+    it("verify default prop of shouldCloseOnOverlayClick", () => {
+      const props = { isOpen: true };
+      withModal(props, null, modal => {
+        modal.props.shouldCloseOnOverlayClick.should.be.ok();
+      });
+    });
+
+    it("verify prop of shouldCloseOnOverlayClick", () => {
+      const modalOpts = { isOpen: true, shouldCloseOnOverlayClick: false };
+      withModal(modalOpts, null, modal => {
+        modal.props.shouldCloseOnOverlayClick.should.not.be.ok();
+      });
+    });
+
+    it("keeps the modal in the DOM until closeTimeoutMS elapses", done => {
+      function checkDOM(count) {
+        const overlay = document.querySelectorAll(".ReactModal__Overlay");
+        const content = document.querySelectorAll(".ReactModal__Content");
+        overlay.length.should.be.eql(count);
+        content.length.should.be.eql(count);
+      }
+      withElementCollector(() => {
+        const closeTimeoutMS = 100;
+        const props = { isOpen: true, closeTimeoutMS };
+        const node = createHTMLElement("div");
+        const modal = ReactDOM.render(<Modal {...props} />, node);
+
+        modal.portal.closeWithTimeout();
+        checkDOM(1);
+
+        setTimeout(() => {
+          checkDOM(0);
+          ReactDOM.unmountComponentAtNode(node);
+          done();
+        }, closeTimeoutMS);
+      });
+    });
+
+    it("verify that portalClassName is refreshed on component update", () => {
+      withElementCollector(() => {
+        const node = createHTMLElement("div");
+        let modal = null;
+
+        class App extends Component {
+          constructor(props) {
+            super(props);
+            this.state = { classModifier: "" };
+          }
+
+          componentDidMount() {
+            modal.node.className.should.be.eql("portal");
+
+            this.setState({ classModifier: "-modifier" });
+          }
+
+          componentDidUpdate() {
+            modal.node.className.should.be.eql("portal-modifier");
+          }
+
+          render() {
+            const { classModifier } = this.state;
+            const portalClassName = `portal${classModifier}`;
+
+            return (
+              <div>
+                <Modal
+                  ref={modalComponent => {
+                    modal = modalComponent;
+                  }}
+                  isOpen
+                  portalClassName={portalClassName}
+                >
+                  <span>Test</span>
+                </Modal>
+              </div>
+            );
+          }
+        }
+
+        Modal.setAppElement(node);
+        ReactDOM.render(<App />, node);
+        ReactDOM.unmountComponentAtNode(node);
+      });
+    });
+
+    it("use overlayRef and contentRef", () => {
+      let overlay = null;
+      let content = null;
+
+      const props = {
+        isOpen: true,
+        overlayRef: node => (overlay = node),
+        contentRef: node => (content = node)
+      };
+      withModal(props, null, () => {
+        overlay.should.be.instanceOf(HTMLElement);
+        content.should.be.instanceOf(HTMLElement);
+        overlay.classList.contains("ReactModal__Overlay");
+        content.classList.contains("ReactModal__Content");
+      });
     });
   });
 };

--- a/specs/helper.js
+++ b/specs/helper.js
@@ -249,6 +249,9 @@ export const withModal = function(props, children, test = noop) {
         node
       );
       test(modal);
+    } catch(e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
     } finally {
       ReactDOM.unmountComponentAtNode(node);
     }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -59,6 +59,7 @@ class Modal extends Component {
       })
     ]),
     appElement: PropTypes.oneOfType([
+      PropTypes.string,
       PropTypes.instanceOf(SafeHTMLElement),
       PropTypes.instanceOf(SafeHTMLCollection),
       PropTypes.instanceOf(SafeNodeList),

--- a/src/helpers/ariaAppHider.js
+++ b/src/helpers/ariaAppHider.js
@@ -1,4 +1,3 @@
-import warning from "warning";
 import { canUseDOM } from "./safeHTMLElement";
 
 let globalElement = null;
@@ -39,49 +38,42 @@ export function assertNodeList(nodeList, selector) {
   }
 }
 
-export function setElement(element) {
-  let useElement = element;
-  if (typeof useElement === "string" && canUseDOM) {
-    const el = document.querySelectorAll(useElement);
-    assertNodeList(el, useElement);
-    useElement = el;
+export function validateElement(element) {
+  if (!element || element.length == 0) {
+    // eslint-disable-next-line no-console
+    throw new Error(
+      [
+        "react-modal: App element is not defined.",
+        "Please use `Modal.setAppElement(el)` or set `appElement={el}`."
+      ].join(" ")
+    );
   }
-  globalElement = useElement || globalElement;
+
+  return Array.isArray(element) ||
+    element instanceof HTMLCollection ||
+    element instanceof NodeList
+    ? element
+    : [element];
+}
+
+export function setElement(element) {
+  if (!canUseDOM) return;
+  globalElement =
+    (typeof element === "string" && document.querySelectorAll(element)) ||
+    ((element instanceof HTMLElement) && [element]) ||
+    globalElement;
+  validateElement(globalElement);
   return globalElement;
 }
 
-export function validateElement(appElement) {
-  const el = appElement || globalElement;
-  if (el) {
-    return Array.isArray(el) ||
-      el instanceof HTMLCollection ||
-      el instanceof NodeList
-      ? el
-      : [el];
-  } else {
-    warning(
-      false,
-      [
-        "react-modal: App element is not defined.",
-        "Please use `Modal.setAppElement(el)` or set `appElement={el}`.",
-        "This is needed so screen readers don't see main content",
-        "when modal is opened. It is not recommended, but you can opt-out",
-        "by setting `ariaHideApp={false}`."
-      ].join(" ")
-    );
-
-    return [];
-  }
-}
-
 export function hide(appElement) {
-  for (let el of validateElement(appElement)) {
+  for (let el of validateElement(appElement || globalElement)) {
     el.setAttribute("aria-hidden", "true");
   }
 }
 
 export function show(appElement) {
-  for (let el of validateElement(appElement)) {
+  for (let el of validateElement(appElement || globalElement)) {
     el.removeAttribute("aria-hidden");
   }
 }


### PR DESCRIPTION
Fixes #988.

Changes proposed:

- One of the options to set the app element are going to be required
because we can't use `document.body` as default (hides all elements on the page).  

Upgrade Path (for changed or removed APIs):

- Must use one of the options.

Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
