### PR TITLE
[fixed]:1015 - Fixed closing by click on layout

### DIFF
--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -222,7 +222,7 @@ export default () => {
       withModal(props, null, modal => {
         mouseDownAt(moverlay(modal));
         mouseUpAt(mcontent(modal));
-        clickAt(mcontent(modal));
+        clickAt(moverlay(modal));
         requestCloseCallback.called.should.not.be.ok();
       });
     });

--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -222,6 +222,7 @@ export default () => {
       withModal(props, null, modal => {
         mouseDownAt(moverlay(modal));
         mouseUpAt(mcontent(modal));
+        clickAt(mcontent(modal));
         requestCloseCallback.called.should.not.be.ok();
       });
     });
@@ -236,8 +237,39 @@ export default () => {
       withModal(props, null, modal => {
         mouseDownAt(mcontent(modal));
         mouseUpAt(moverlay(modal));
+        clickAt(moverlay(modal));
         requestCloseCallback.called.should.not.be.ok();
       });
+    });
+
+    it("click on button containing stopPropagation inside modal shouldn't block closing", () => {
+      const requestCloseCallback = sinon.spy();
+      let innerButton = null;
+      let innerButtonRef = ref => {
+        innerButton = ref;
+      };
+      function click(event) {
+        event.stopPropagation();
+      }
+
+      withModal(
+        {
+          isOpen: true,
+          onRequestClose: requestCloseCallback
+        },
+        <button ref={innerButtonRef} onClick={click} />,
+        modal => {
+          // imitate regular click with all mouse events on button inside modal
+          mouseDownAt(innerButton);
+          mouseUpAt(innerButton);
+          clickAt(innerButton);
+          // imitate regular click with all mouse events on modal overlay
+          mouseDownAt(moverlay(modal));
+          mouseUpAt(moverlay(modal));
+          clickAt(moverlay(modal));
+          requestCloseCallback.called.should.be.ok();
+        }
+      );
     });
   });
 

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -322,13 +322,15 @@ export default class ModalPortal extends Component {
     if (!this.props.shouldCloseOnOverlayClick && event.target == this.overlay) {
       event.preventDefault();
     }
+    this.shouldClose = null;
   };
 
   handleContentOnClick = () => {
     this.shouldClose = false;
   };
 
-  handleContentOnMouseDown = () => {
+  handleContentOnMouseDown = event => {
+    event.stopPropagation();
     this.shouldClose = false;
   };
 


### PR DESCRIPTION
Fixes #1015

Changes proposed:

- Fix incorrect behavior when you need to click twice on the overlay to close modal window if you click on something with event.stopPropagation() inside content block and add a test case for that.
- Fix test cases for the overlay MD -> content MU && content MD -> overlay MU cases because they don't work correctly without the "click" itself.

Upgrade Path (for changed or removed APIs): -

Acceptance Checklist:
- [ ] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [ ] Documentation (README.md) and examples have been updated as needed.
- [ ] If this is a code change, a spec testing the functionality has been added.
- [ ] If the commit message has [changed] or [removed], there is an upgrade path above.
