### PR TITLE
Comment the ellipsis in code blocks in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -186,7 +186,7 @@ choose a different parent element by providing a function to the
 
 ```jsx
 <Modal
-  ...
+  // ...
   parentSelector={() => document.querySelector('#root')}>
   <p>Modal Content.</p>
 </Modal>
@@ -202,7 +202,7 @@ You can use ref callbacks to get the overlay and content DOM nodes directly:
 
 ```jsx
 <Modal
-  ...
+  // ...
   overlayRef={node => (this.overlayRef = node)}
   contentRef={node => (this.contentRef = node)}>
   <p>Modal Content.</p>


### PR DESCRIPTION
Super simple change, but it is to ensure proper syntax highlighting in http://reactcommunity.org/react-modal/

Right now it's showing error on the ellipsis because it's not a valid entity in JSX. This also affects the line after the ellipsis.

<img width="853" alt="image" src="https://github.com/reactjs/react-modal/assets/6047296/cce6950e-7f4d-4cd6-b34a-21db1b2ff8c5">

Once the ellipsis is commented out, the syntax highlighting should become correct for the line after it.

Changes proposed:

- Comment the ellipsis in code blocks in docs/index.md


Acceptance Checklist:
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
