### PR TITLE
[fixed] Prevent unintended register and unregister #808

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -133,7 +133,7 @@ export default class ModalPortal extends Component {
   }
 
   componentWillUnmount() {
-    if (this.state.isOpen) {
+    if (this.props.isOpen) {
       this.afterClose();
     }
     clearTimeout(this.closeTimer);
@@ -227,11 +227,11 @@ export default class ModalPortal extends Component {
   };
 
   open = () => {
-    this.beforeOpen();
     if (this.state.afterOpen && this.state.beforeClose) {
       clearTimeout(this.closeTimer);
       this.setState({ beforeClose: false });
     } else {
+      this.beforeOpen();
       if (this.props.shouldFocusAfterRender) {
         focusManager.setupScopedFocus(this.node);
         focusManager.markForFocusLater();
@@ -268,24 +268,21 @@ export default class ModalPortal extends Component {
 
   closeWithTimeout = () => {
     const closesAt = Date.now() + this.props.closeTimeoutMS;
-    this.setState({ beforeClose: true, closesAt }, () => {
-      this.closeTimer = setTimeout(
-        this.closeWithoutTimeout,
-        this.state.closesAt - Date.now()
-      );
-    });
+    this.setState({ beforeClose: true, closesAt });
+    this.closeTimer = setTimeout(
+      this.closeWithoutTimeout,
+      this.props.closeTimeoutMS
+    );
   };
 
   closeWithoutTimeout = () => {
-    this.setState(
-      {
-        beforeClose: false,
-        isOpen: false,
-        afterOpen: false,
-        closesAt: null
-      },
-      this.afterClose
-    );
+    this.setState({
+      beforeClose: false,
+      isOpen: false,
+      afterOpen: false,
+      closesAt: null
+    });
+    this.afterClose();
   };
 
   handleKeyDown = event => {


### PR DESCRIPTION
- Fixed #808
- Checking `this.props.isOpen` instead of `this.state.isOpen` in `componentWillUnmount`.
- Moved the call to `this.beforeOpen()` from the beginning of the `open` method to an else block.
- Set `this.closeTimer` without waiting until the end of the setState.
- Call `this.afterClose()` directly after setting the state in `closeWithoutTimeout`.

Tested environment
- `React` ^18
- `React.StrictMode` / without `React.StrictMode`
(I tested it with reference to https://github.com/reactjs/react-modal/issues/808#issuecomment-1445230192)

This PR also fixes the problem regarding conditional rendering.



Acceptance Checklist:
- [x] Tests
- [x] Documentation and examples (if needed)

Fixes #808 
