### PR TITLE
Use CloseWatcher API when available

### DIFF
--- a/specs/helper.js
+++ b/specs/helper.js
@@ -93,6 +93,15 @@ if (!String.prototype.includes) {
 }
 
 /**
+ * hide the native close watcher; we don't have a way to test it yet,
+ * the implementation will fall back to using normal keydown events
+ * as usual.
+ */
+if (window.CloseWatcher) {
+  delete window.CloseWatcher;
+}
+
+/**
  * Return the class list object from `document.body`.
  * @return {Array}
  */

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -27,10 +27,6 @@ const isEscKey = event => event.code === "Escape" || event.keyCode === 27;
 
 let ariaHiddenInstances = 0;
 
-// Check if CloseWatcher API is available
-const supportsCloseWatcher =
-  typeof window !== "undefined" && "CloseWatcher" in window;
-
 export default class ModalPortal extends Component {
   static defaultProps = {
     style: {
@@ -233,7 +229,7 @@ export default class ModalPortal extends Component {
   };
 
   setupCloseWatcher = () => {
-    if (supportsCloseWatcher && this.props.shouldCloseOnEsc) {
+    if (typeof CloseWatcher !== "undefined" && this.props.shouldCloseOnEsc) {
       this.closeWatcher = new window.CloseWatcher();
       this.closeWatcher.onclose = event => {
         if (this.props.shouldCloseOnEsc) {
@@ -324,7 +320,7 @@ export default class ModalPortal extends Component {
     // CloseWatcher emits for both native close (Android back) and Escape.
     // Without it, we can fall back to ordinary keydown events from Escape.
     if (
-      !supportsCloseWatcher &&
+      typeof CloseWatcher === "undefined" &&
       this.props.shouldCloseOnEsc &&
       isEscKey(event)
     ) {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -27,6 +27,10 @@ const isEscKey = event => event.code === "Escape" || event.keyCode === 27;
 
 let ariaHiddenInstances = 0;
 
+// Check if CloseWatcher API is available
+const supportsCloseWatcher =
+  typeof window !== "undefined" && "CloseWatcher" in window;
+
 export default class ModalPortal extends Component {
   static defaultProps = {
     style: {
@@ -90,6 +94,7 @@ export default class ModalPortal extends Component {
 
     this.shouldClose = null;
     this.moveFromContentToOverlay = null;
+    this.closeWatcher = null;
   }
 
   componentDidMount() {
@@ -138,6 +143,7 @@ export default class ModalPortal extends Component {
     }
     clearTimeout(this.closeTimer);
     cancelAnimationFrame(this.openAnimationFrame);
+    this.destroyCloseWatcher();
   }
 
   setOverlayRef = overlay => {
@@ -226,6 +232,24 @@ export default class ModalPortal extends Component {
     portalOpenInstances.deregister(this);
   };
 
+  setupCloseWatcher = () => {
+    if (supportsCloseWatcher && this.props.shouldCloseOnEsc) {
+      this.closeWatcher = new window.CloseWatcher();
+      this.closeWatcher.onclose = event => {
+        if (this.props.shouldCloseOnEsc) {
+          this.requestClose(event);
+        }
+      };
+    }
+  };
+
+  destroyCloseWatcher = () => {
+    if (this.closeWatcher) {
+      this.closeWatcher.destroy();
+      this.closeWatcher = null;
+    }
+  };
+
   open = () => {
     this.beforeOpen();
     if (this.state.afterOpen && this.state.beforeClose) {
@@ -236,6 +260,8 @@ export default class ModalPortal extends Component {
         focusManager.setupScopedFocus(this.node);
         focusManager.markForFocusLater();
       }
+
+      this.setupCloseWatcher();
 
       this.setState({ isOpen: true }, () => {
         this.openAnimationFrame = requestAnimationFrame(() => {
@@ -277,6 +303,7 @@ export default class ModalPortal extends Component {
   };
 
   closeWithoutTimeout = () => {
+    this.destroyCloseWatcher();
     this.setState(
       {
         beforeClose: false,
@@ -293,7 +320,14 @@ export default class ModalPortal extends Component {
       scopeTab(this.content, event);
     }
 
-    if (this.props.shouldCloseOnEsc && isEscKey(event)) {
+    // Handle escape key for closing when CloseWatcher is not supported.
+    // CloseWatcher emits for both native close (Android back) and Escape.
+    // Without it, we can fall back to ordinary keydown events from Escape.
+    if (
+      !supportsCloseWatcher &&
+      this.props.shouldCloseOnEsc &&
+      isEscKey(event)
+    ) {
       event.stopPropagation();
       this.requestClose(event);
     }

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -231,10 +231,13 @@ export default class ModalPortal extends Component {
   setupCloseWatcher = () => {
     if (typeof CloseWatcher !== "undefined" && this.props.shouldCloseOnEsc) {
       this.closeWatcher = new window.CloseWatcher();
-      this.closeWatcher.onclose = event => {
-        if (this.props.shouldCloseOnEsc) {
-          this.requestClose(event);
+      this.closeWatcher.oncancel = event => {
+        if (!this.props.shouldCloseOnEsc) {
+          event.preventDefault();
         }
+      };
+      this.closeWatcher.onclose = event => {
+        this.requestClose(event);
       };
     }
   };


### PR DESCRIPTION
This issue was first raised years ago in #875 when CloseWatcher was just a proposal. Now [it is part of the official HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#close-requests-and-close-watchers). Chrome has been shipping this since v126 (June 2024) and Firefox has an implementation behind a feature flag.

This PR takes a progressive enhancement approach. If the API is available it is used instead of ordinary Escape `keydown` events for closing.

**However, there's a big potential pitfall with this naive approach:** when a CloseWatcher emits a `close` event, it _will be destroyed_ and no further events emitted. This library's design is at odds with this, where consumers control the open state, and can choose not to respond to a requested close.

The correct behavior from the CloseWatcher's perspective is to also listen to `cancel` events, and call `preventDefault` on those. This PR attempts to do that as long as `shouldCloseOnEsc` is false, but there's nothing requiring consumers to pass that instead of simply deciding not to respond to a `onRequestClose` callback. If consumers don't idiomatically pass `shouldCloseOnEsc` and instead just ignore `onRequestClose`, the Escape/back key will not be able to close the modal after the first attempt, as the CloseWatcher would have been destroyed at that point. 

I believe strongly in adding support for `CloseWatcher` to this package now, in spite of this pitfall. Perhaps we could introduce an additional `shouldCloseByCloseWatcher` prop, to let consumers opt-in to the progressive enhancement of CloseWatcher? By starting with an opt-in approach, consumers can adjust their usage to always respect a `onRequestClose` callback.

Acceptance Checklist:
- [ ] Tests
  - This is a bit tricky. In order to fully test CloseWatcher we need a way to trigger trusted keypress events in the browser, rather than merely sending synthetic events via React Test Library. I'm not very familiar with mocha/karma but I poked around didn't see an easy way to do this.
- [ ] Documentation and examples (if needed)
  - This doesn't change the API at all, but we could add additional clarification that `shouldCloseOnEsc={false}` now also prevents closing with Android's back button.