### PR TITLE
fix: close modal on first overlay click after stopped propagation

### DIFF
--- a/specs/Modal.events.spec.js
+++ b/specs/Modal.events.spec.js
@@ -239,6 +239,37 @@ export default () => {
         requestCloseCallback.called.should.not.be.ok();
       });
     });
+
+    it("closes on first overlay click after content click stops propagation", () => {
+      const requestCloseCallback = sinon.spy();
+      let innerButton = null;
+      const setInnerButton = ref => {
+        innerButton = ref;
+      };
+      const stopPropagation = event => event.stopPropagation();
+
+      const props = {
+        isOpen: true,
+        shouldCloseOnOverlayClick: true,
+        onRequestClose: requestCloseCallback
+      };
+
+      withModal(
+        props,
+        <button ref={setInnerButton} onClick={stopPropagation} />,
+        modal => {
+          mouseDownAt(innerButton);
+          mouseUpAt(innerButton);
+          clickAt(innerButton);
+
+          mouseDownAt(moverlay(modal));
+          mouseUpAt(moverlay(modal));
+          clickAt(moverlay(modal));
+
+          requestCloseCallback.calledOnce.should.be.ok();
+        }
+      );
+    });
   });
 
   it("should not stop event propagation", () => {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -90,6 +90,7 @@ export default class ModalPortal extends Component {
 
     this.shouldClose = null;
     this.moveFromContentToOverlay = null;
+    this.preventOverlayMouseDown = false;
   }
 
   componentDidMount() {
@@ -322,6 +323,12 @@ export default class ModalPortal extends Component {
     if (!this.props.shouldCloseOnOverlayClick && event.target == this.overlay) {
       event.preventDefault();
     }
+
+    if (this.preventOverlayMouseDown) {
+      this.preventOverlayMouseDown = false;
+    } else if (event.target == this.overlay) {
+      this.shouldClose = null;
+    }
   };
 
   handleContentOnClick = () => {
@@ -330,6 +337,7 @@ export default class ModalPortal extends Component {
 
   handleContentOnMouseDown = () => {
     this.shouldClose = false;
+    this.preventOverlayMouseDown = true;
   };
 
   requestClose = event =>


### PR DESCRIPTION
Fixes #1015.

## Summary
- track when a content mouse down should suppress the next overlay mouse down
- clear stale overlay-close state only on a real overlay mouse down
- add a regression test for a content click that stops propagation followed by an overlay click

## Validation
- npm run lint
- NODE_OPTIONS=--openssl-legacy-provider npm run test -- --single-run